### PR TITLE
Fix #128

### DIFF
--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -124,13 +124,13 @@ class EarthRangerIO(ERClient):
         self,
         include_inactive=None,
         bbox=None,
-        subject_group=None,
+        subject_group_id=None,
         name=None,
         updated_since=None,
         tracks=None,
         id=None,
         updated_until=None,
-        group_name=None,
+        subject_group_name=None,
         max_ids_per_request=50,
         **addl_kwargs,
     ):
@@ -140,13 +140,15 @@ class EarthRangerIO(ERClient):
         include_inactive: Include inactive subjects in list.
         bbox: Include subjects having track data within this bounding box defined by a 4-tuple of coordinates marking
             west, south, east, north.
-        subject_group: Indicate a subject group for which Subjects should be listed.
+        subject_group_id: Indicate a subject group id for which Subjects should be listed.
+            This is translated to the subject_group parameter in the ER backend
         name : Find subjects with the given name
         updated_since: Return Subject that have been updated since the given timestamp.
         tracks: Indicate whether to render each subject's recent tracks.
         id: A comma-delimited list of Subject IDs.
         updated_until
-        group_name
+        subject_group_name: A subject group name for which Subjects should be listed.
+            This is translated to the group_name parameter in the ER backend
         Returns
         -------
         subjects : pd.DataFrame
@@ -156,13 +158,13 @@ class EarthRangerIO(ERClient):
             addl_kwargs,
             include_inactive=include_inactive,
             bbox=bbox,
-            subject_group=subject_group,
+            subject_group=subject_group_id,
             name=name,
             updated_since=updated_since,
             tracks=tracks,
             id=id,
             updated_until=updated_until,
-            group_name=group_name,
+            group_name=subject_group_name,
         )
 
         assert params.get("subject_group") is None or params.get("group_name") is None

--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -491,13 +491,15 @@ class EarthRangerIO(ERClient):
         else:
             return observations
 
-    def get_subjectgroup_observations(self, subject_group=None, group_name=None, include_inactive=True, **kwargs):
+    def get_subjectgroup_observations(
+        self, subject_group_id=None, subject_group_name=None, include_inactive=True, **kwargs
+    ):
         """
         Parameters
         ----------
-        subject_group : str
+        subject_group_id : str
             UUID of subject group to filter by
-        group_name : str
+        subject_group_name : str
             Common name of subject group to filter by
         include_inactive : bool, optional
             Whether to get observations for Subjects marked inactive by EarthRanger
@@ -510,12 +512,12 @@ class EarthRangerIO(ERClient):
             Observations in `Relocations` format
         """
 
-        assert (subject_group is None) != (group_name is None)
+        assert (subject_group_id is None) != (subject_group_name is None)
 
-        if subject_group:
-            subjects = self.get_subjects(subject_group=subject_group, include_inactive=include_inactive)
+        if subject_group_id:
+            subjects = self.get_subjects(subject_group=subject_group_id, include_inactive=include_inactive)
         else:
-            subjects = self.get_subjects(group_name=group_name, include_inactive=include_inactive)
+            subjects = self.get_subjects(group_name=subject_group_name, include_inactive=include_inactive)
 
         return self.get_subject_observations(subjects, **kwargs)
 

--- a/notebooks/01. IO/EarthRanger_IO.ipynb
+++ b/notebooks/01. IO/EarthRanger_IO.ipynb
@@ -423,7 +423,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### By `SubjectGroup` `group_name`"
+    "### By `SubjectGroup` `subject_group_name`"
    ]
   },
   {
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "er_io.get_subjects(group_name=\"Elephants\")"
+    "er_io.get_subjects(subject_group_name=\"Elephants\")"
    ]
   },
   {

--- a/notebooks/01. IO/EarthRanger_IO.ipynb
+++ b/notebooks/01. IO/EarthRanger_IO.ipynb
@@ -459,7 +459,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### By `SubjectGroup` `group_name`:"
+    "### By `SubjectGroup` `subject_group_name`:"
    ]
   },
   {
@@ -479,7 +479,7 @@
    "outputs": [],
    "source": [
     "relocs = er_io.get_subjectgroup_observations(\n",
-    "    group_name=\"Elephants\",\n",
+    "    subject_group_name=\"Elephants\",\n",
     "    filter=0,\n",
     "    since=since,\n",
     "    until=until,\n",
@@ -704,7 +704,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "elephants = er_io.get_subjectgroup_observations(group_name=\"Elephants\", since=pd.Timestamp(\"2022-01-01\").isoformat())\n",
+    "elephants = er_io.get_subjectgroup_observations(\n",
+    "    subject_group_name=\"Elephants\", since=pd.Timestamp(\"2022-01-01\").isoformat()\n",
+    ")\n",
     "\n",
     "if not elephants.empty:\n",
     "    for i, value in elephants.iterrows():\n",
@@ -834,7 +836,7 @@
    "outputs": [],
    "source": [
     "relocs = er_io.get_subjectgroup_observations(\n",
-    "    group_name=\"Elephants\",\n",
+    "    subject_group_name=\"Elephants\",\n",
     "    filter=0,\n",
     "    since=since,\n",
     "    until=until,\n",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@ import ecoscope
 @pytest.mark.skipif(not pytest.earthranger, reason="No connection to EarthRanger")
 def test_trajectory_is_not_empty(er_io):
     # test there is actually data in trajectory
-    relocations = er_io.get_subjectgroup_observations(group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
     trajectory = ecoscope.base.Trajectory.from_relocations(relocations)
     assert not trajectory.empty
 
@@ -19,7 +19,7 @@ def test_trajectory_is_not_empty(er_io):
 @pytest.mark.skipif(not pytest.earthranger, reason="No connection to EarthRanger")
 def test_redundant_columns_in_trajectory(er_io):
     # test there is no redundant column in trajectory
-    relocations = er_io.get_subjectgroup_observations(group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
     trajectory = ecoscope.base.Trajectory.from_relocations(relocations)
     assert "extra__fixtime" not in trajectory
     assert "extra___fixtime" not in trajectory
@@ -28,7 +28,7 @@ def test_redundant_columns_in_trajectory(er_io):
 
 @pytest.mark.skipif(not pytest.earthranger, reason="No connection to EarthRanger")
 def test_relocs_speedfilter(er_io):
-    relocations = er_io.get_subjectgroup_observations(group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
     relocs_speed_filter = ecoscope.base.RelocsSpeedFilter(max_speed_kmhr=8)
     relocs_after_filter = relocations.apply_reloc_filter(relocs_speed_filter)
     relocs_after_filter.remove_filtered(inplace=True)
@@ -37,7 +37,7 @@ def test_relocs_speedfilter(er_io):
 
 @pytest.mark.skipif(not pytest.earthranger, reason="No connection to EarthRanger")
 def test_relocs_distancefilter(er_io):
-    relocations = er_io.get_subjectgroup_observations(group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
     relocs_speed_filter = ecoscope.base.RelocsDistFilter(min_dist_km=1.0, max_dist_km=6.0)
     relocs_after_filter = relocations.apply_reloc_filter(relocs_speed_filter)
     relocs_after_filter.remove_filtered(inplace=True)
@@ -46,7 +46,7 @@ def test_relocs_distancefilter(er_io):
 
 @pytest.mark.skipif(not pytest.earthranger, reason="No connection to EarthRanger")
 def test_relocations_from_gdf_preserve_fields(er_io):
-    relocations = er_io.get_subjectgroup_observations(group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
     gpd.testing.assert_geodataframe_equal(relocations, ecoscope.base.Relocations.from_gdf(relocations))
 
 

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -217,3 +217,13 @@ def test_get_spatial_features_group(er_io):
         spatial_features_group_id="15698426-7e0f-41df-9bc3-495d87e2e097"
     )
     assert not spatial_features.empty
+
+
+def test_get_subjects_chunking(er_io):
+    subject_ids = ",".join(er_io.SUBJECT_IDS)
+    single_request_result = er_io.get_subjects(id=subject_ids)
+    print(f"single {single_request_result}")
+    chunked_request_result = er_io.get_subjects(id=subject_ids, max_ids_per_request=1)
+    print(f"chunk {chunked_request_result}")
+
+    pd.testing.assert_frame_equal(single_request_result, chunked_request_result)

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -17,7 +17,7 @@ if not pytest.earthranger:
 
 def test_get_subject_observations(er_io):
     relocations = er_io.get_subject_observations(
-        subject_ids=er_io.SUBJECT_IDS,
+        subjects=er_io.SUBJECT_IDS,
         include_subject_details=True,
         include_source_details=True,
         include_subjectsource_details=True,

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -66,7 +66,7 @@ def test_get_subjectsource_no_observations(er_io):
 
 
 def test_get_subjectgroup_observations(er_io):
-    relocations = er_io.get_subjectgroup_observations(group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
     assert "groupby_col" in relocations
 
 

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -17,7 +17,7 @@ if not pytest.earthranger:
 
 def test_get_subject_observations(er_io):
     relocations = er_io.get_subject_observations(
-        subjects=er_io.SUBJECT_IDS,
+        subject_ids=er_io.SUBJECT_IDS,
         include_subject_details=True,
         include_source_details=True,
         include_subjectsource_details=True,
@@ -222,8 +222,6 @@ def test_get_spatial_features_group(er_io):
 def test_get_subjects_chunking(er_io):
     subject_ids = ",".join(er_io.SUBJECT_IDS)
     single_request_result = er_io.get_subjects(id=subject_ids)
-    print(f"single {single_request_result}")
     chunked_request_result = er_io.get_subjects(id=subject_ids, max_ids_per_request=1)
-    print(f"chunk {chunked_request_result}")
 
     pd.testing.assert_frame_equal(single_request_result, chunked_request_result)

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -190,6 +190,7 @@ def test_patch_event(er_io):
     pd.testing.assert_frame_equal(result, updated_event)
 
 
+@pytest.mark.skip(reason="Known issue: https://github.com/wildlife-dynamics/ecoscope/issues/109")
 def test_get_patrol_observations(er_io):
     patrols = er_io.get_patrols()
     observations = er_io.get_patrol_observations(


### PR DESCRIPTION
This fixes 2 separate issues that relate to [#128](https://github.com/wildlife-dynamics/ecoscope/issues/128)

1. Originally `get_subjectgroup_observations` would:
    - first call `get_subjects()` for a given group, which would return all subject data, but only the ids were kept
    - call to `er._get_observations()` with the gathered subject ids
    - if `include_subject_details=True` then we also call `get_subjects()` _again_ with a concatenated list of the same subject id's retrieved by the original call 

This PR reworks the flow to keep the returned subjects for the original call to be used in the event of `include_subject_details=True`

2. There was no protection on the number of subject_ids passed to `get_subjects()` allowing one to fetch a large number of individual id's in a single request. This PR will now chunk the requests into a parameterised number of subject_ids per request, defaulting to 50.

(There's also a one-liner to skip a test relating to [this](https://github.com/wildlife-dynamics/ecoscope/issues/109) issue)
