### PR TITLE
Workflow for releasing to PyPi 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - changelog-ignore
+  categories:
+    - title: Breaking Changes
+      labels:
+        - changelog-breaking
+    - title: New Features
+      labels:
+        - changelog-enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,12 @@ jobs:
     - build
     - install
     runs-on: ubuntu-latest
+    environment:
+      name: release
     if: startsWith(github.ref, 'refs/tags/')
+
+    permissions:
+      id-token: write
       
     steps:
       - name: Grab the previously stored build
@@ -71,8 +76,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          repository-url: https://upload.pypi.org/legacy/
+          repository-url: https://pypi.org/p/${{ env.PACKAGE }}
 
   github-release:
     name: Create release on GH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,110 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  PYTHON_VERSION: "3.10.12"
+  PACKAGE: "ecoscope"
+  
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: pip-dist
+        path: dist/
+
+  install:
+    name: Install package
+    runs-on: "ubuntu-latest"
+    needs:
+    - build
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: pip-dist
+          path: dist/
+      - name: Install package
+        run: python -m pip install dist/*.whl
+      - name: Test package
+        run: python -c "import $PACKAGE"  
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs:
+    - build
+    - install
+    runs-on: ubuntu-latest
+      
+    steps:
+      - name: Grab the previously stored build
+        uses: actions/download-artifact@v4
+        with:
+          name: pip-dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://upload.pypi.org/legacy/
+
+  github-release:
+    name: Create release on GH
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write 
+      id-token: write 
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: pip-dist
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --generate-notes
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
-name: Publish
+name: Build
 
 on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - "main"
 
 env:
   PYTHON_VERSION: "3.10.12"
@@ -58,6 +60,7 @@ jobs:
     - build
     - install
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
       
     steps:
       - name: Grab the previously stored build
@@ -76,6 +79,7 @@ jobs:
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
 
     permissions:
       contents: write 


### PR DESCRIPTION
Closes #177 

Adds workflow triggered by tag push that builds and publishes to PyPi and creates a signed release on GitHub.

Also adds yaml config for generating release notes based on PR labels.
I've set this up so that PR's fall in 3 categories:
- "Breaking Changes" labeled as `changelog-breaking`
- "New Features" labeled as `changelog-enhancement`
- "Other" (for anything unlabeled). 

There's also `changelog-ignore` for anything we want to explicitly leave out.