### PR TITLE
Use meters instead of km as the default distance unit when calculating feature density

### DIFF
--- a/ecoscope/analysis/feature_density.py
+++ b/ecoscope/analysis/feature_density.py
@@ -8,7 +8,7 @@ def calculate_feature_density(selection, grid, geometry_type="point"):
         if geometry_type == "point":
             return result.geometry.count()
         elif geometry_type == "line":
-            return result.geometry.length.sum() / 1000
+            return result.geometry.length.sum()
         else:
             raise ValueError("Unsupported geometry type")
 

--- a/tests/test_feature_density.py
+++ b/tests/test_feature_density.py
@@ -53,8 +53,8 @@ def test_feature_density_line():
 
     density_grid = calculate_feature_density(lines, grid, geometry_type="line")
 
-    assert math.isclose(density_grid["density"].sum(), 183.66716408789358)
-    assert math.isclose(density_grid["density"].max(), 6.209056409759374)
+    assert math.isclose(density_grid["density"].sum(), 183667.16408789358)
+    assert math.isclose(density_grid["density"].max(), 6209.056409759374)
     ecoscope.io.raster.grid_to_raster(
         density_grid, val_column="density", out_dir="tests/test_output", raster_name="line_density.tif"
     )


### PR DESCRIPTION
#93 