### PR TITLE
190/display names

### DIFF
--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -869,15 +869,24 @@ class EarthRangerIO(ERClient):
         spatial_feature = self._get(object, **params)
         return gpd.GeoDataFrame.from_features(spatial_feature["features"])
 
-    def get_event_display_name(self, key):
+    def get_event_display_name(self, key, event_type=None):
         if self._display_map is None:
             self._get_display_names()
+
+        if event_type is not None:
+            return self._display_map.get(event_type).get(key)
 
         return self._display_map.get(key)
 
     def _get_display_names(self):
         event_types = self.get_event_types()
-        self._display_map = dict([(row["value"], row["display"]) for _, row in event_types.iterrows()])
+        self._display_map = dict([(row["value"], {"display": row["display"]}) for _, row in event_types.iterrows()])
+
+        # should probably split this out into _get_event_type_fields(key) and add a flag here to not call by default
+        for k, _ in self._display_map.items():
+            schema = self.get_event_type(k)
+            schema_props = schema["schema"]["properties"]
+            self._display_map.get(k)["properties"] = dict([(k, v["title"]) for k, v in schema_props.items()])
 
     """
     POST Functions

--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -29,6 +29,7 @@ class EarthRangerIO(ERClient):
 
         self.sub_page_size = sub_page_size
         self.tcp_limit = tcp_limit
+        self._display_map = None
         kwargs["client_id"] = kwargs.get("client_id", "das_web_client")
         super().__init__(**kwargs)
         try:
@@ -867,6 +868,16 @@ class EarthRangerIO(ERClient):
         object = f"spatialfeature/{spatial_feature_id}/"
         spatial_feature = self._get(object, **params)
         return gpd.GeoDataFrame.from_features(spatial_feature["features"])
+
+    def get_event_display_name(self, key):
+        if self._display_map is None:
+            self._get_display_names()
+
+        return self._display_map.get(key)
+
+    def _get_display_names(self):
+        event_types = self.get_event_types()
+        self._display_map = dict([(row["value"], row["display"]) for _, row in event_types.iterrows()])
 
     """
     POST Functions

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -76,6 +76,17 @@ def test_get_events(er_events_io):
     assert not events.empty
 
 
+def test_get_event_types(er_io):
+    events = er_io.get_event_types()
+    assert not events.empty
+    assert len(events.columns) == 15
+
+
+def test_get_event_display_name(er_io):
+    assert er_io.get_event_display_name("mep_distance_count") == "MEP Distance Count"
+    assert er_io.get_event_display_name("cameratrap_rep") == "Camera Trap"
+
+
 def test_das_client_method(er_io):
     er_io.pulse()
     er_io.get_me()


### PR DESCRIPTION
This is just a WIP for discussion, I think this is better suited to an [async](https://github.com/wildlife-dynamics/ecoscope/issues/195) version of the `earthranger.py`, where the `display_map` dict is 'prefetched' asynchronously on `init()` 

I wanted see how we feel about using `EarthRangerIO` as a cache of data that's relatively static, such as these event type display names, patrol types, etc