### PR TITLE
Fix get events

### DIFF
--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -641,8 +641,8 @@ class EarthRangerIO(ERClient):
             gdf.loc[~gdf["geojson"].isna(), "geometry"] = gpd.GeoDataFrame.from_features(
                 gdf.loc[~gdf["geojson"].isna(), "geojson"]
             )["geometry"]
+            gdf.set_geometry("geometry", inplace=True)
             gdf.set_crs(4326, inplace=True)
-
         gdf.sort_values("time", inplace=True)
         return gdf.set_index("id")
 

--- a/notebooks/01. IO/EarthRanger_IO.ipynb
+++ b/notebooks/01. IO/EarthRanger_IO.ipynb
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "er_io.get_events(\n",
-    "    event_ids=\"c623e691-0f62-435c-91be-48b4742a04ec\",  # Distance count event\n",
+    "    event_ids=\"4347de4e-8dc2-4f52-bab1-0e1843eba2a1\",  # Distance count event\n",
     ")"
    ]
   },


### PR DESCRIPTION
Explicitly sets geometry column when transforming the events returned from ER into a GDF
Updates reference event id in tutorial notebook to one that actually exists