### PR TITLE
Bump actions/checkout version from v2 -> v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         env: [environment.yml]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1


### PR DESCRIPTION
@enlivn recently reported timeouts in github actions runs.

Taking a look at one of the failed runs here

https://github.com/wildlife-dynamics/ecoscope/actions/runs/10199970227/attempts/1

I noted this error
```
The process '/usr/bin/git' failed with exit code 128
```
is the same as is reported in https://github.com/actions/checkout/issues/417.

While it does seem some users on that thread are still encountering this issue with `actions/checkout@v4`, to me it's notable that we are two major versions behind on this action (currently running v2), so as a first step it can't hurt to bump to the latests version. If the problem persists, we can explore some of the other workarounds in the linked thread.
