### PR TITLE
Make async earthranger client optional

### DIFF
--- a/ecoscope/io/__init__.py
+++ b/ecoscope/io/__init__.py
@@ -15,15 +15,6 @@ __all__ = [
 try:
     from ecoscope.io.async_earthranger import AsyncEarthRangerIO
 
-    __all__ = [
-        "earthranger",
-        "EarthRangerIO",
-        "AsyncEarthRangerIO",
-        "download_file",
-        "earthranger_utils",
-        "eetools",
-        "raster",
-        "utils",
-    ]
+    __all__ += ["AsyncEarthRangerIO"]
 except ImportError:
     pass

--- a/ecoscope/io/__init__.py
+++ b/ecoscope/io/__init__.py
@@ -1,15 +1,29 @@
 from ecoscope.io import earthranger, eetools, raster, utils
 from ecoscope.io.earthranger import EarthRangerIO
-from ecoscope.io.async_earthranger import AsyncEarthRangerIO
 from ecoscope.io.utils import download_file
 
 __all__ = [
     "earthranger",
     "EarthRangerIO",
-    "AsyncEarthRangerIO",
     "download_file",
     "earthranger_utils",
     "eetools",
     "raster",
     "utils",
 ]
+
+try:
+    from ecoscope.io.async_earthranger import AsyncEarthRangerIO
+
+    __all__ = [
+        "earthranger",
+        "EarthRangerIO",
+        "AsyncEarthRangerIO",
+        "download_file",
+        "earthranger_utils",
+        "eetools",
+        "raster",
+        "utils",
+    ]
+except ImportError:
+    pass

--- a/ecoscope/io/async_earthranger.py
+++ b/ecoscope/io/async_earthranger.py
@@ -3,11 +3,18 @@ import geopandas as gpd
 import pandas as pd
 import asyncio
 from dateutil import parser
-from erclient.client import AsyncERClient
+
+import ecoscope
 from ecoscope.io.utils import to_hex
 from ecoscope.io.earthranger_utils import clean_kwargs, to_gdf
 
-import ecoscope
+try:
+    from erclient.client import AsyncERClient
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        'Missing optional dependencies required by this module. \
+         Please run pip install ecoscope["async_earthranger"]'
+    )
 
 
 class AsyncEarthRangerIO(AsyncERClient):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers=[
 dependencies = [
     "backoff",
     "earthengine-api",
-    "earthranger-client @ git+https://github.com/PADAS/er-client@v1.2.3",
+    "earthranger-client",
     "geopandas<=0.14.2",
     "pyproj",
     "rasterio",
@@ -49,6 +49,9 @@ analysis = [
     "scipy",
     "scikit-image",
     "scikit-learn",
+]
+async_earthranger = [
+    "earthranger-client @ git+https://github.com/PADAS/er-client@v1.2.3",
 ]
 mapping = [
     "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@77c56d30a9c2dd96fd863e910bf62952cfa36da8",


### PR DESCRIPTION
This is to unblock an upstream issue with `ecoscope-workflows` 

All versions of `earthranger-client` with async functionality are pinned to `pydantic<2` which causes a dependency conflict in `ecoscope-workflows` when installing versions of `ecoscope` that depend on those particular versions of `earthranger-client` (because `ecoscope-workflows` requires `pydantic>2`)

This makes the async client an optional dependency and disables our async functionality if it's not present.

This is a temporary bandaid as we definitely want `ecoscope-workflows` to make use of the async client ASAP, but to unblock development in the short term this is necessary.