### PR TITLE
ignore dependabot prs from changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "changelog-ignore"


### PR DESCRIPTION
Just adds the `changelog-ignore` label to dependabot config