### PR TITLE
Allow `io.grid_to_raster` to return a `rio.MemoryFile`

### DIFF
--- a/doc/source/notebooks/04. EcoMap & EcoPlot/EcoMap.ipynb
+++ b/doc/source/notebooks/04. EcoMap & EcoPlot/EcoMap.ipynb
@@ -332,7 +332,7 @@
     "\n",
     "m = EcoMap(width=800, height=600)\n",
     "m.add_layer(EcoMap.get_named_tile_layer(\"OpenStreetMap\"))\n",
-    "m.add_geotiff(path=os.path.join(output_dir, \"mara_dem.tif\"), zoom=True, cmap=\"jet\")\n",
+    "m.add_geotiff(tiff=os.path.join(output_dir, \"mara_dem.tif\"), zoom=True, cmap=\"jet\")\n",
     "m"
    ]
   },

--- a/ecoscope/io/raster.py
+++ b/ecoscope/io/raster.py
@@ -208,7 +208,7 @@ def raster_to_gdf(raster_path):
         )
 
 
-def grid_to_raster(grid=None, val_column="", out_dir="", raster_name="grid.tif", xlen=5000, ylen=5000, grid_crs=4326):
+def grid_to_raster(grid=None, val_column="", out_dir="", raster_name=None, xlen=5000, ylen=5000, grid_crs=4326):
     """
     Save a GeoDataFrame grid to a raster.
     """
@@ -231,8 +231,20 @@ def grid_to_raster(grid=None, val_column="", out_dir="", raster_name="grid.tif",
     raster_profile.raster_extent = ecoscope.io.raster.RasterExtent(
         x_min=bounds[0], x_max=bounds[2], y_min=bounds[1], y_max=bounds[3]
     )
-    ecoscope.io.raster.RasterPy.write(
-        ndarray=vals,
-        fp=os.path.join(out_dir, raster_name),
-        **raster_profile,
-    )
+
+    if raster_name:
+        ecoscope.io.raster.RasterPy.write(
+            ndarray=vals,
+            fp=os.path.join(out_dir, raster_name),
+            **raster_profile,
+        )
+    else:
+        memfile = rio.MemoryFile()
+        memfile.open(
+            driver="GTiff",
+            width=raster_profile.pop("columns"),
+            height=raster_profile.pop("rows"),
+            count=raster_profile.pop("band_count"),
+            **raster_profile,
+        ).write(vals)
+        return memfile

--- a/ecoscope/io/raster.py
+++ b/ecoscope/io/raster.py
@@ -208,7 +208,7 @@ def raster_to_gdf(raster_path):
         )
 
 
-def grid_to_raster(grid=None, val_column="", out_dir="", raster_name=None, xlen=5000, ylen=5000, grid_crs=4326):
+def grid_to_raster(grid=None, val_column="", out_dir="", raster_name=None, xlen=5000, ylen=5000):
     """
     Save a GeoDataFrame grid to a raster.
     """
@@ -223,7 +223,7 @@ def grid_to_raster(grid=None, val_column="", out_dir="", raster_name=None, xlen=
 
     raster_profile = ecoscope.io.raster.RasterProfile(
         pixel_size=xlen,
-        crs=grid_crs,
+        crs=grid.crs.to_epsg(),
         nodata_value=np.nan,
         band_count=1,
     )

--- a/ecoscope/io/raster.py
+++ b/ecoscope/io/raster.py
@@ -246,5 +246,6 @@ def grid_to_raster(grid=None, val_column="", out_dir="", raster_name=None, xlen=
             height=raster_profile.pop("rows"),
             count=raster_profile.pop("band_count"),
             **raster_profile,
-        ).write(vals)
+        ).write(vals, 1)
+
         return memfile

--- a/ecoscope/mapping/map.py
+++ b/ecoscope/mapping/map.py
@@ -382,7 +382,7 @@ class EcoMap(EcoMapMixin, Map):
         Parameters
         ----------
         tiff : str | rio.MemoryFile
-            The path to the local tiff
+            The string path to a tiff on disk or a rio.MemoryFile
         zoom : bool
             Whether to zoom the map to the bounds of the tiff
         cmap: str or matplotlib.colors.Colormap

--- a/ecoscope/mapping/map.py
+++ b/ecoscope/mapping/map.py
@@ -7,7 +7,8 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from io import BytesIO
-from typing import Dict, List, Union
+from typing import Dict, IO, List, Optional, TextIO, Union
+from pathlib import Path
 
 try:
     import matplotlib as mpl
@@ -509,6 +510,17 @@ class EcoMap(EcoMapMixin, Map):
             min_zoom=layer.get("min_zoom", None),
             max_requests=layer.get("max_requests", None),
         )
+
+    def to_html(
+        self,
+        filename: Union[str, Path, TextIO, IO[str], None] = None,
+        title: Optional[str] = None,
+        maximize: bool = True,
+    ) -> Union[None, str]:
+        if maximize:
+            self.height = "100%"
+            self.width = "100%"
+        return super().to_html(filename=filename, title=title)
 
     @staticmethod
     def hex_to_rgb(hex: str) -> list:

--- a/ecoscope/mapping/map.py
+++ b/ecoscope/mapping/map.py
@@ -6,6 +6,7 @@ import geopandas as gpd
 
 import numpy as np
 import pandas as pd
+import rasterio as rio
 from io import BytesIO
 from typing import Dict, IO, List, Optional, TextIO, Union
 from pathlib import Path
@@ -368,7 +369,7 @@ class EcoMap(EcoMapMixin, Map):
 
     def add_geotiff(
         self,
-        path: str,
+        tiff: str | rio.MemoryFile,
         zoom: bool = False,
         cmap: Union[str, mpl.colors.Colormap] = None,
         opacity: float = 0.7,
@@ -380,7 +381,7 @@ class EcoMap(EcoMapMixin, Map):
 
         Parameters
         ----------
-        path : str
+        tiff : str | rio.MemoryFile
             The path to the local tiff
         zoom : bool
             Whether to zoom the map to the bounds of the tiff
@@ -389,7 +390,7 @@ class EcoMap(EcoMapMixin, Map):
         opacity: float
             The opacity of the overlay
         """
-        with rasterio.open(path) as src:
+        with rasterio.open(tiff) as src:
             transform, width, height = rasterio.warp.calculate_default_transform(
                 src.crs, "EPSG:4326", src.width, src.height, *src.bounds
             )

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
       - coverage[toml]
       - earthranger-client @ git+https://github.com/PADAS/er-client@v1.2.3
       - ecoscope
-      - lonboard @ git+https://github.com/wildlife-dynamics/lonboard@77c56d30a9c2dd96fd863e910bf62952cfa36da8
+      - lonboard @ git+https://github.com/wildlife-dynamics/lonboard@a8adb48ec43fff795506db5a9e7e0103f877d65c
       - nbsphinx
       - sphinx-autoapi
       - dask[dataframe]

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - git
   - jupyterlab
   - geopandas<=0.14.2
+  - numpy<2
   - ipywidgets
   - pip:
       - kaleido

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "earthengine-api",
     "earthranger-client",
     "geopandas<=0.14.2",
+    "numpy<2",
     "pyproj",
     "rasterio",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ async_earthranger = [
     "earthranger-client @ git+https://github.com/PADAS/er-client@v1.2.3",
 ]
 mapping = [
-    "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@77c56d30a9c2dd96fd863e910bf62952cfa36da8",
+    "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@a8adb48ec43fff795506db5a9e7e0103f877d65c",
     "matplotlib",
     "mapclassify",
 ]

--- a/tests/test_ecomap.py
+++ b/tests/test_ecomap.py
@@ -230,7 +230,6 @@ def test_add_geotiff_in_mem_with_cmap():
     raster = ecoscope.io.raster.grid_to_raster(
         grid,
         val_column="fake_density",
-        grid_crs=AOI.crs,
     )
 
     m = EcoMap()

--- a/tests/test_ecomap.py
+++ b/tests/test_ecomap.py
@@ -234,7 +234,6 @@ def test_add_geotiff_in_mem_with_cmap():
 
     m = EcoMap()
     m.add_geotiff(raster, cmap="jet")
-    m.to_html("in_mem_raster.html")
     assert len(m.layers) == 2
     assert isinstance(m.layers[1], BitmapLayer)
 

--- a/tests/test_ecomap.py
+++ b/tests/test_ecomap.py
@@ -1,3 +1,5 @@
+import os
+import random
 import ee
 import geopandas as gpd
 import pandas as pd
@@ -211,6 +213,29 @@ def test_add_geotiff():
 def test_add_geotiff_with_cmap():
     m = EcoMap()
     m.add_geotiff("tests/sample_data/raster/uint8.tif", cmap="jet")
+    assert len(m.layers) == 2
+    assert isinstance(m.layers[1], BitmapLayer)
+
+
+def test_add_geotiff_in_mem_with_cmap():
+    AOI = gpd.read_file(os.path.join("tests/sample_data/vector", "maec_4zones_UTM36S.gpkg"))
+
+    grid = gpd.GeoDataFrame(
+        geometry=ecoscope.base.utils.create_meshgrid(
+            AOI.unary_union, in_crs=AOI.crs, out_crs=AOI.crs, xlen=5000, ylen=5000, return_intersecting_only=False
+        )
+    )
+
+    grid["fake_density"] = grid.apply(lambda _: random.randint(1, 50), axis=1)
+    raster = ecoscope.io.raster.grid_to_raster(
+        grid,
+        val_column="fake_density",
+        grid_crs=AOI.crs,
+    )
+
+    m = EcoMap()
+    m.add_geotiff(raster, cmap="jet")
+    m.to_html("in_mem_raster.html")
     assert len(m.layers) == 2
     assert isinstance(m.layers[1], BitmapLayer)
 


### PR DESCRIPTION
closes #253 