### PR TITLE
Fix async tests

### DIFF
--- a/tests/test_asyncearthranger_io.py
+++ b/tests/test_asyncearthranger_io.py
@@ -44,7 +44,6 @@ def get_events_fields():
         "icon_id",
         "serial_number",
         "event_details",
-        "files",
         "related_subjects",
         "event_category",
         "url",
@@ -96,6 +95,7 @@ def get_subjects_fields():
         "country",
         "sex",
         "hex",
+        "messaging",
     ]
 
 


### PR DESCRIPTION
Closes #354 
On the one hand I like these explicit checks for the total set of fields we get back from the ER API as they flag upstream changes clearly to us.
On the other hand it might be too much maintenance and perhaps testing for a minimum set of fields that our logic requires is better. 

I'll leave it for now but it's something to keep an eye on.