### PR TITLE
Bump lonboard

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
       - coverage[toml]
       - earthranger-client @ git+https://github.com/PADAS/er-client@v1.3.3
       - ecoscope
-      - lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.3
+      - lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.4
       - nbsphinx
       - sphinx-autoapi
       - dask[dataframe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ async_earthranger = [
   "earthranger-client @ git+https://github.com/PADAS/er-client@v1.3.3",
 ]
 mapping = [
-  "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.3",
+  "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.4",
   "matplotlib",
   "mapclassify",
 ]


### PR DESCRIPTION
Closes #463 

Bumps to a version of our fork that pins the embedded jupyter-widget html-manager url