### PR TITLE
Ensure grid_size_from_geographic_extent returns a minimum value of 1 

### DIFF
--- a/ecoscope/analysis/UD/etd_range.py
+++ b/ecoscope/analysis/UD/etd_range.py
@@ -247,4 +247,4 @@ def grid_size_from_geographic_extent(gdf: gpd.GeoDataFrame, scale_factor: int = 
     diagonal_distance = Geod(ellps="WGS84").inv(local_bounds[0], local_bounds[1], local_bounds[2], local_bounds[3])[2]
     local_cell_size = diagonal_distance / scale_factor
 
-    return int(round(local_cell_size, 0))
+    return max(1, int(round(local_cell_size, 0)))

--- a/tests/test_ud.py
+++ b/tests/test_ud.py
@@ -5,6 +5,7 @@ import geopandas as gpd
 import geopandas.testing
 import numpy as np
 import pytest
+from shapely.geometry import Point
 
 import ecoscope
 from ecoscope.analysis.UD import calculate_etd_range, grid_size_from_geographic_extent
@@ -96,6 +97,9 @@ def test_reduce_regions(aoi_gdf):
 
 
 def test_grid_size_from_geographic_extent(movebank_relocations, aoi_gdf, sample_observations):
+    small_extent = gpd.GeoDataFrame(geometry=[Point(0.0001, 0.0002), Point(0.0002, 0.0001)], crs="EPSG:4326")
+    assert 1 == grid_size_from_geographic_extent(small_extent)
+
     relocs_gdf = movebank_relocations.gdf
     # aoi_gdf.total_bounds = [34.798, -1.901, 36.001, -0.997], smallest extent
     aoi_gdf_cell_size = grid_size_from_geographic_extent(aoi_gdf)


### PR DESCRIPTION
Closes #496

We now return the max of 1, or the calculated auto-scale value- which effectively means the minimum auto-scale size is 1 metre