### PR TITLE
Update `apply_color_map` to properly handle columns that are entirely nan values in all cases

### DIFF
--- a/ecoscope/analysis/classifier.py
+++ b/ecoscope/analysis/classifier.py
@@ -134,11 +134,14 @@ def apply_color_map(
 
     nunique = dataframe[input_column_name].nunique()
     unique = dataframe[input_column_name].unique()
-    if isinstance(cmap, list):
+    if nunique == 0:
+        NAN_COLOR = (0, 0, 0, 0)
+        cmap_series = pd.Series([NAN_COLOR], index=unique)
+    elif isinstance(cmap, list):
         rgba = [hex_to_rgba(x) for x in cmap]
         normalized_cmap = [rgba[i % len(rgba)] for i in range(nunique)]
         cmap_series = pd.Series(normalized_cmap, index=unique)
-    if isinstance(cmap, str):
+    elif isinstance(cmap, str):
         mpl_cmap = mpl.colormaps[cmap]
         if nunique < mpl_cmap.N:
             mpl_cmap = mpl_cmap.resampled(nunique)

--- a/ecoscope/analysis/classifier.py
+++ b/ecoscope/analysis/classifier.py
@@ -135,6 +135,9 @@ def apply_color_map(
     nunique = dataframe[input_column_name].nunique()
     unique = dataframe[input_column_name].unique()
     if nunique == 0:
+        # nunique == 0 when input_column contains only nan values
+        # in this case we manually set the color values to transparent
+        # rather than rely on mpl, which may or may not handle nans properly
         NAN_COLOR = (0, 0, 0, 0)
         cmap_series = pd.Series([NAN_COLOR], index=unique)
     elif isinstance(cmap, list):

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -166,7 +166,20 @@ def test_apply_colormap_numeric_with_float_range():
     assert len(df["colormap"].unique()) == len(df["value"].unique())
 
 
-@pytest.mark.parametrize("colormap", ["viridis", "RdYlGn_r", "Reds", "copper", "twilight", "Set1", "flag"])
+@pytest.mark.parametrize(
+    "colormap",
+    ["viridis", "RdYlGn_r", "Reds", "copper", "twilight", "Set1", "flag", ["#FF0000"]],
+    ids=[
+        "mpl.viridis",
+        "mpl.RdYlGn_r",
+        "mpl.Reds",
+        "mpl.copper",
+        "mpl.twilight",
+        "mpl.Set1",
+        "mpl.flag",
+        "user defined",
+    ],
+)
 def test_apply_colormap_numeric_nan_only(colormap):
     df = pd.DataFrame(
         data={"value": [np.nan, np.nan]},

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -181,17 +181,17 @@ def test_apply_colormap_numeric_nan_only():
 @pytest.mark.parametrize(
     "values",
     [
-        [np.nan, 2.0],
-        [np.nan, 1.0, 10.0, 9.0],
-        [np.nan, 2.0],
-        [np.nan, 2.0],
-        [np.nan, 2.0, 20.0],
+        # [np.nan, 2.0],
+        # [np.nan, 1.0, 10.0, 9.0],
+        # [np.nan, 2.0],
+        # [np.nan, 2.0],
+        # [np.nan, 2.0, 20.0],
         [np.nan],
-        [np.nan, 2.0],
-        [np.nan, 1.0, 31.0],
-        [np.nan, 27.0, 1.0],
-        [np.nan, 204.0, 438.0, 345.0, 116.0, 1.0],
-        [np.nan, 3.0, 4.0],
+        # [np.nan, 2.0],
+        # [np.nan, 1.0, 31.0],
+        # [np.nan, 27.0, 1.0],
+        # [np.nan, 204.0, 438.0, 345.0, 116.0, 1.0],
+        # [np.nan, 3.0, 4.0],
     ],
 )
 def test_apply_colormap_leaf(values):
@@ -200,7 +200,7 @@ def test_apply_colormap_leaf(values):
     )
     apply_color_map(df, "value", "RdYlGn_r", output_column_name="colormap")
 
-    assert len(df["colormap"].unique()) == len(df["value"].unique())
+    # assert len(df["colormap"].unique()) == len(df["value"].unique())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -179,6 +179,31 @@ def test_apply_colormap_numeric_nan_only():
 
 
 @pytest.mark.parametrize(
+    "values",
+    [
+        [np.nan, 2.0],
+        [np.nan, 1.0, 10.0, 9.0],
+        [np.nan, 2.0],
+        [np.nan, 2.0],
+        [np.nan, 2.0, 20.0],
+        [np.nan],
+        [np.nan, 2.0],
+        [np.nan, 1.0, 31.0],
+        [np.nan, 27.0, 1.0],
+        [np.nan, 204.0, 438.0, 345.0, 116.0, 1.0],
+        [np.nan, 3.0, 4.0],
+    ],
+)
+def test_apply_colormap_leaf(values):
+    df = pd.DataFrame(
+        data={"value": values},
+    )
+    apply_color_map(df, "value", "RdYlGn_r", output_column_name="colormap")
+
+    assert len(df["colormap"].unique()) == len(df["value"].unique())
+
+
+@pytest.mark.parametrize(
     "percentile_levels,expected_values",
     [
         ([10, 50, 90], [90, 90, 50, 50, 10]),

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -166,41 +166,17 @@ def test_apply_colormap_numeric_with_float_range():
     assert len(df["colormap"].unique()) == len(df["value"].unique())
 
 
-def test_apply_colormap_numeric_nan_only():
+@pytest.mark.parametrize("colormap", ["viridis", "RdYlGn_r", "reds", "copper", "twilight", "set1", "flag"])
+def test_apply_colormap_numeric_nan_only(colormap):
     df = pd.DataFrame(
         data={"value": [np.nan, np.nan]},
         index=["A", "B"],
     )
-    apply_color_map(df, "value", "viridis", output_column_name="colormap")
+    apply_color_map(df, "value", colormap, output_column_name="colormap")
 
     assert len(df["colormap"].unique()) == len(df["value"].unique())
     assert df.loc["A"]["colormap"] == (0, 0, 0, 0)
     assert df.loc["B"]["colormap"] == (0, 0, 0, 0)
-
-
-@pytest.mark.parametrize(
-    "values",
-    [
-        # [np.nan, 2.0],
-        # [np.nan, 1.0, 10.0, 9.0],
-        # [np.nan, 2.0],
-        # [np.nan, 2.0],
-        # [np.nan, 2.0, 20.0],
-        [np.nan],
-        # [np.nan, 2.0],
-        # [np.nan, 1.0, 31.0],
-        # [np.nan, 27.0, 1.0],
-        # [np.nan, 204.0, 438.0, 345.0, 116.0, 1.0],
-        # [np.nan, 3.0, 4.0],
-    ],
-)
-def test_apply_colormap_leaf(values):
-    df = pd.DataFrame(
-        data={"value": values},
-    )
-    apply_color_map(df, "value", "RdYlGn_r", output_column_name="colormap")
-
-    # assert len(df["colormap"].unique()) == len(df["value"].unique())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -166,7 +166,7 @@ def test_apply_colormap_numeric_with_float_range():
     assert len(df["colormap"].unique()) == len(df["value"].unique())
 
 
-@pytest.mark.parametrize("colormap", ["viridis", "RdYlGn_r", "reds", "copper", "twilight", "set1", "flag"])
+@pytest.mark.parametrize("colormap", ["viridis", "RdYlGn_r", "Reds", "copper", "twilight", "Set1", "flag"])
 def test_apply_colormap_numeric_nan_only(colormap):
     df = pd.DataFrame(
         data={"value": [np.nan, np.nan]},


### PR DESCRIPTION
Closes #519 

Per #519, nan input causes the mpl lookup to fail for certain colormaps, so this PR:
- Explicitly handles this case outside of mpl
- Improves the test coverage in the scenario to a wider range of colormaps