### PR TITLE
Update tile layer widget id type from int to string

### DIFF
--- a/ecoscope/mapping/map.py
+++ b/ecoscope/mapping/map.py
@@ -24,7 +24,14 @@ try:
         TitleWidget,
     )
     from lonboard._geoarrow.ops.bbox import Bbox
-    from lonboard._layer import BaseLayer, BitmapLayer, BitmapTileLayer, PathLayer, PolygonLayer, ScatterplotLayer
+    from lonboard._layer import (
+        BaseLayer,
+        BitmapLayer,
+        BitmapTileLayer,
+        PathLayer,
+        PolygonLayer,
+        ScatterplotLayer,
+    )
     from lonboard._viewport import bbox_to_zoom_level, compute_view
 
 except ModuleNotFoundError:
@@ -119,7 +126,11 @@ class EcoMap(Map):
             if static:
                 kwargs["deck_widgets"] = [ScaleWidget()]
             else:
-                kwargs["deck_widgets"] = [FullscreenWidget(), ScaleWidget(), SaveImageWidget()]
+                kwargs["deck_widgets"] = [
+                    FullscreenWidget(),
+                    ScaleWidget(),
+                    SaveImageWidget(),
+                ]
 
         if static:
             kwargs["controller"] = False
@@ -359,7 +370,11 @@ class EcoMap(Map):
 
         return ee_layer
 
-    def zoom_to_bounds(self, feat: Union[BaseLayer, Sequence[BaseLayer], gpd.GeoDataFrame], max_zoom: int = 20):
+    def zoom_to_bounds(
+        self,
+        feat: Union[BaseLayer, Sequence[BaseLayer], gpd.GeoDataFrame],
+        max_zoom: int = 20,
+    ):
         """
         Zooms the map to the bounds of a dataframe or layer.
 
@@ -416,7 +431,14 @@ class EcoMap(Map):
                 src.crs, "EPSG:4326", src.width, src.height, *src.bounds
             )
             rio_kwargs = src.meta.copy()
-            rio_kwargs.update({"crs": "EPSG:4326", "transform": transform, "width": width, "height": height})
+            rio_kwargs.update(
+                {
+                    "crs": "EPSG:4326",
+                    "transform": transform,
+                    "width": width,
+                    "height": height,
+                }
+            )
 
             # new
             bounds = rio.warp.transform_bounds(src.crs, "EPSG:4326", *src.bounds)
@@ -490,7 +512,7 @@ class EcoMap(Map):
         return layer
 
     @staticmethod
-    def get_named_tile_layer(layer: str, widget_id: Optional[int] = None, opacity: float = 1) -> BitmapTileLayer:
+    def get_named_tile_layer(layer: str, widget_id: Optional[str] = None, opacity: float = 1) -> BitmapTileLayer:
         layer_def = TILE_LAYERS.get(layer)
         if not layer_def:
             raise ValueError("layer name must be in  {}".format(", ".join(TILE_LAYERS.keys())))

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
       - coverage[toml]
       - earthranger-client@ git+https://github.com/PADAS/er-client@v1.3.3
       - ecoscope
-      - lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.6
+      - lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.7
       - mypy
       - nbsphinx
       - sphinx-autoapi

--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -49,7 +49,7 @@ requirements:
     # - scikit-learn  # duplicate with analysis
     # ~ mapping ~
     - duckdb
-    - lonboard==0.0.5
+    - lonboard==0.0.7
     - pyarrow
     # - matplotlib  # duplicate with analysis
     # - mapclassify  # duplicate with analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ analysis = [
 ]
 mapping = [
   "duckdb",
-  "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.6",
+  "lonboard @ git+https://github.com/wildlife-dynamics/lonboard@v0.0.7",
   "matplotlib",
   "mapclassify",
   "pyarrow",

--- a/tests/test_ecomap.py
+++ b/tests/test_ecomap.py
@@ -350,6 +350,18 @@ def test_add_named_tile_layer():
     assert m.layers[0].opacity == 0.3
 
 
+def test_add_named_tile_layer_with_widget_id():
+    m = EcoMap()
+    widget_id = "THIS IS A TEST STRING"
+    m.add_layer(m.get_named_tile_layer("TERRAIN", opacity=0.3, widget_id=widget_id))
+
+    assert len(m.layers) == 1
+    assert isinstance(m.layers[0], BitmapTileLayer)
+    assert m.layers[0].opacity == 0.3
+    output = m.to_html()
+    assert widget_id in output
+
+
 def test_clean_gdf(point_gdf):
     dirty_gdf = point_gdf.copy(deep=True)
     dirty_gdf.at[0, "geometry"] = None


### PR DESCRIPTION
Closes #517
Revises #518, which originally added the widget_id as an `int` because plots require us to have the widget ID as `string` even though maps can handle an `int`, and we want to have the same code on web treat both types of widgets.