### PR TITLE
Tag patrol events with patrol subject

### DIFF
--- a/ecoscope/io/earthranger_utils.py
+++ b/ecoscope/io/earthranger_utils.py
@@ -134,6 +134,7 @@ def unpack_events_from_patrols_df(
                     event["patrol_segment_id"] = segment.get("id")
                     event["patrol_start_time"] = (segment.get("time_range") or {}).get("start_time")
                     event["patrol_type"] = segment.get("patrol_type")
+                    event["patrol_subject"] = (segment.get("leader") or {}).get("name")
                     events.append(event)
     events_df = pd.DataFrame(events)
     if events_df.empty:

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -165,6 +165,7 @@ def test_get_patrol_events(er_io):
     assert "patrol_id" in events
     assert "patrol_segment_id" in events
     assert "patrol_start_time" in events
+    assert "patrol_subject" in events
     assert "patrol_type" in events
     assert "patrol_serial_number" in events
     assert "time" in events


### PR DESCRIPTION
## :earth_americas: Summary
Closes #534 
## :package: Proposed Changes
Updates `unpack_events_from_patrols_df` to tag each patrol event with the respective patrol_subject
