### PR TITLE
Sort normalized columns

### DIFF
--- a/ecoscope/io/earthranger_utils.py
+++ b/ecoscope/io/earthranger_utils.py
@@ -23,10 +23,13 @@ def clean_kwargs(addl_kwargs: dict | None = None, **kwargs) -> dict:
     return {k: v for k, v in {**addl_kwargs, **kwargs}.items() if v is not None}
 
 
-def normalize_column(df: pd.DataFrame, col: str) -> None:
+def normalize_column(df: pd.DataFrame, col: str, sort_columns: bool = False) -> None:
     normalized = pd.json_normalize(df.pop(col).to_list(), sep="__").add_prefix(f"{col}__")
 
-    new_cols = sorted(normalized.columns.tolist())
+    new_cols = normalized.columns.tolist()
+    if sort_columns:
+        new_cols = sorted(new_cols)
+
     for k in new_cols:
         df[k] = normalized[k].values  # type: ignore[call-overload]
 

--- a/tests/test_earthranger_utils.py
+++ b/tests/test_earthranger_utils.py
@@ -78,10 +78,6 @@ def test_normalize_column():
     assert all(col in df_with_nested_column.columns for col in original_cols)
     assert all(col in df_with_nested_column.columns for col in expected_new_cols)
 
-    # Verify column order: original columns first, then alphabetically sorted new columns
-    expected_column_order = original_cols + expected_new_cols
-    assert list(df_with_nested_column.columns) == expected_column_order
-
     # Verify values were correctly normalized
     assert list(df_with_nested_column["details__apple"]) == ["a1", "a2", "a3"]
     assert list(df_with_nested_column["details__middle"]) == ["m1", "m2", "m3"]
@@ -91,3 +87,31 @@ def test_normalize_column():
     assert list(df_with_nested_column["id"]) == [1, 2, 3]
     assert list(df_with_nested_column["name"]) == ["Alice", "Bob", "Charlie"]
     assert list(df_with_nested_column["score"]) == [10, 20, 30]
+
+
+def test_normalize_column_sorted():
+    df_with_nested_column = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "details": [
+                {"zebra": "z1", "apple": "a1", "middle": "m1"},
+                {"zebra": "z2", "apple": "a2", "middle": "m2"},
+                {"zebra": "z3", "apple": "a3", "middle": "m3"},
+            ],
+            "score": [10, 20, 30],
+        }
+    )
+
+    # Store original column order (excluding the one to be normalized)
+    original_cols = ["id", "name", "score"]
+
+    # Normalize the 'details' column
+    normalize_column(df_with_nested_column, "details", sort_columns=True)
+
+    # Expected new columns in alphabetical order
+    expected_new_cols = ["details__apple", "details__middle", "details__zebra"]
+
+    # Verify column order: original columns first, then alphabetically sorted new columns
+    expected_column_order = original_cols + expected_new_cols
+    assert list(df_with_nested_column.columns) == expected_column_order


### PR DESCRIPTION
Closes #563

## :earth_americas: Summary
Users report that the output of normalize_column is not consistent across different sites with the same event model

## :package: Proposed Changes
The plan is to sort the normalized columns alphabetically and append them after existing DataFrame columns.
