### PR TITLE
Add `statsmodels` to recipe

### DIFF
--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -51,6 +51,7 @@ requirements:
     - duckdb
     - lonboard==0.0.8
     - pyarrow
+    - statsmodels
     # - matplotlib  # duplicate with analysis
     # - mapclassify  # duplicate with analysis
 


### PR DESCRIPTION
## :earth_americas: Summary
Closes #571

## :package: Proposed Changes
Adds `statsmodels` as a dependency in the release recipe, this dependency was introduced with #553 
