### PR TITLE
Strip leading v's from tags that trigger publish.yml before passing to rattler-build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
           name: pip-dist
           path: dist/
       - name: Add tag to recipe
-        run: sed -i "s/TAG_VERSION/${{ github.ref_name }}/g" publish/recipes/release/ecoscope.yaml
+        run: sed -i "s/TAG_VERSION/${GITHUB_REF_NAME#v}/g" publish/recipes/release/ecoscope.yaml
       - name: Add dist to recipe
         run: sed -i "s/DIST_NAME/$(find ./dist/*.tar.gz  -printf "%f\n")/g" publish/recipes/release/ecoscope.yaml
       - name: Log the generated recipe


### PR DESCRIPTION
## :earth_americas: Summary

closes #622

## :package: Proposed Changes

- As title suggests, leading `v`s should be stripped from tags before being passed to rattler-build to avoid double v issue on prefix.dev index

