### PR TITLE
Fix miss on _drop_skip_sentinals parity in port of ecoscope-workflows-core groupby tasks

### DIFF
--- a/ecoscope/platform/tasks/groupby/_groupby.py
+++ b/ecoscope/platform/tasks/groupby/_groupby.py
@@ -140,7 +140,7 @@ def _drop_skip_sentinels(
     iterables: list[KeyedIterableOfAny],
 ) -> list[KeyedIterableOfAny]:
     """Drop any SkipSentinel values from the keyed iterable."""
-    return [i for i in iterables for elem in i if not isinstance(elem[1], SkipSentinel)]
+    return [[(key, value) for key, value in i if not isinstance(value, SkipSentinel)] for i in iterables]
 
 
 @register()

--- a/tests/platform/tasks/test_groupby.py
+++ b/tests/platform/tasks/test_groupby.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from wt_task.skip import SKIP_SENTINEL
 
 from ecoscope.platform.indexes import CompositeFilter, IndexName, IndexValue
 from ecoscope.platform.tasks.groupby import (


### PR DESCRIPTION
## :earth_americas: Summary

closes #625

## :package: Proposed Changes

- 1:1 copy of the change described in https://github.com/wildlife-dynamics/ecoscope-workflows/pull/1307/changes#r2850016298, as implemented by @atmorling, along with associated tests
- I am surprised we missed this in #610, for sanity I can schedule a tech debt ticket to do another agent-assisted pass through the two codebases to find any logical differences (with a focus on recently-merged changes to ecoscope-workflows, as it's most likely these would have been missed, if they came in as/after the migration began).

