### PR TITLE
add codecov token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,3 +74,5 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ docs = [
   "mkdocstrings[python]>=0.24.0",
   "myst-parser",
   "nbsphinx",
-  "pydata-sphinx-theme",
+  "pydata-sphinx-theme<0.17.0",
   "sphinx",
   "sphinx-autoapi",
 ]


### PR DESCRIPTION
## :earth_americas: Summary
Closes #202 

## :package: Proposed Changes
- Adds `CODECOV_TOKEN` to CI tests
- Upper bounds pydata-sphinx-theme as the latest version is breaking our docs build (xref this [issue](https://www.github.com/pydata/pydata-sphinx-theme/issues/2349))

The coverage numbers attached to this PR are skewed because of how out of date codecov's idea of the main branch is - expecting this to be fine once this PR is merged

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary