### PR TITLE
Add data warehouse dependencies in ecoscope pkg

### DIFF
--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -78,6 +78,7 @@ outputs:
         - cloudpathlib-gs
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
+        - ecoscope-earthranger-io-core ==0.0.7
     tests:
       - python:
           imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.5",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.7",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",


### PR DESCRIPTION
## :earth_americas: Summary
Closes #671

## :package: Proposed Changes
- Adds `ecoscope-earthranger-io-core` in the rattle build recipe, so that it's available for workflows using the data warehouse
- Updates `ecoscope-earthranger-io-core` to the latest version 

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary