### PR TITLE
Update ecoscope-earthranger-io-core to v0.0.10

### DIFF
--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -78,7 +78,7 @@ outputs:
         - cloudpathlib-gs
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
-        - ecoscope-earthranger-io-core ==0.0.9
+        - ecoscope-earthranger-io-core ==0.0.10
     tests:
       - python:
           imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.9",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.10",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",


### PR DESCRIPTION
## :earth_americas: Summary
Closes #676
Related to [ERDW-186](https://allenai.atlassian.net/browse/ERDW-186)

## :package: Proposed Changes
Update `ecoscope-earthranger-io-core` to `v0.0.10` to get the latest changes in request auth for DWH

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary

[ERDW-186]: https://allenai.atlassian.net/browse/ERDW-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ