### PR TITLE
feat: polygon event support

### DIFF
--- a/ecoscope/platform/connections.py
+++ b/ecoscope/platform/connections.py
@@ -115,6 +115,7 @@ class EarthRangerClientProtocol(Protocol):
         include_details: bool,
         include_updates: bool,
         include_related_events: bool,
+        force_point_geometry: bool,
     ) -> AnyGeoDataFrame: ...
 
     def get_event_types(self) -> AnyDataFrame: ...

--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -234,6 +234,16 @@ IncludeRelatedEventsAnnotation = Annotated[
         description="Whether or not to include related events",
     ),
 ]
+ForcePointGeometryAnnotation = Annotated[
+    bool,
+    AdvancedField(
+        default=True,
+        description=(
+            "If True, polygon/multipolygon event geometries are reduced to their centroid."
+            " Set False to preserve native geometry types."
+        ),
+    ),
+]
 AnalysisFieldAnnotation = Annotated[
     str,
     Field(
@@ -584,6 +594,7 @@ def get_events(
     include_updates: IncludeUpdatesAnnotation = False,
     include_related_events: IncludeRelatedEventsAnnotation = False,
     include_display_values: IncludeDisplayValuesAnnotation = False,
+    force_point_geometry: ForcePointGeometryAnnotation = True,
 ) -> EventGDF | EventsWithDisplayNamesGDF | EmptyDataFrame:
     """Get events."""
     event_type_ids: list[str] = []
@@ -607,6 +618,7 @@ def get_events(
             include_details=include_details,
             include_updates=include_updates,
             include_related_events=include_related_events,
+            force_point_geometry=force_point_geometry,
         )
     )
 

--- a/ecoscope/platform/tasks/transformation/__init__.py
+++ b/ecoscope/platform/tasks/transformation/__init__.py
@@ -12,6 +12,7 @@ from ._conversion import (
 from ._exploding import explode
 from ._extract import extract_column_as_type, extract_value_from_json_column
 from ._filter import filter_df
+from ._filter_by_geometry_type import filter_by_geometry_type
 from ._filtering import (
     BoundingBox,
     Coordinate,
@@ -55,6 +56,7 @@ __all__ = [
     "extract_column_as_type",
     "extract_value_from_json_column",
     "filter_df",
+    "filter_by_geometry_type",
     "apply_reloc_coord_filter",
     "drop_nan_values_by_column",
     "drop_null_geometry",

--- a/ecoscope/platform/tasks/transformation/_filter_by_geometry_type.py
+++ b/ecoscope/platform/tasks/transformation/_filter_by_geometry_type.py
@@ -1,0 +1,31 @@
+from typing import Annotated, cast
+
+from pydantic import Field
+from wt_registry import register
+
+from ecoscope.platform.annotations import AnyGeoDataFrame
+
+
+@register()
+def filter_by_geometry_type(
+    df: AnyGeoDataFrame,
+    geometry_types: Annotated[
+        list[str],
+        Field(
+            description=("Shapely geometry type names to keep " "(e.g. ['Point'], ['Polygon', 'MultiPolygon'])."),
+        ),
+    ],
+) -> AnyGeoDataFrame:
+    """
+    Filter a GeoDataFrame to rows whose geometry type is in ``geometry_types``.
+
+    Args:
+        df: Input GeoDataFrame.
+        geometry_types: List of shapely ``geom_type`` names to retain.
+
+    Returns:
+        GeoDataFrame containing only rows whose geometry's ``geom_type`` is in
+        ``geometry_types``.
+    """
+    filtered = df[df.geometry.geom_type.isin(geometry_types)]
+    return cast(AnyGeoDataFrame, filtered)

--- a/ecoscope/platform/tasks/transformation/_filtering.py
+++ b/ecoscope/platform/tasks/transformation/_filtering.py
@@ -79,10 +79,18 @@ def apply_reloc_coord_filter(
         if geometry is None:
             return True
 
-        # Non-Point geometries (e.g. Polygon, MultiPolygon) are pass-through:
-        # bounding-box / exact-coord filtering only applies to point relocations.
+        # For non-Point geometries (e.g. Polygon, MultiPolygon), keep rows whose
+        # geometry intersects the bounding box. The exact-coord filter only
+        # makes sense for point relocations, so it doesn't apply here.
         if geometry.geom_type != "Point":
-            return True
+            return geometry.intersects(
+                shapely.geometry.box(
+                    bounding_box.min_x,
+                    bounding_box.min_y,
+                    bounding_box.max_x,
+                    bounding_box.max_y,
+                )
+            )
 
         return (
             geometry.x > bounding_box.min_x

--- a/ecoscope/platform/tasks/transformation/_filtering.py
+++ b/ecoscope/platform/tasks/transformation/_filtering.py
@@ -79,6 +79,11 @@ def apply_reloc_coord_filter(
         if geometry is None:
             return True
 
+        # Non-Point geometries (e.g. Polygon, MultiPolygon) are pass-through:
+        # bounding-box / exact-coord filtering only applies to point relocations.
+        if geometry.geom_type != "Point":
+            return True
+
         return (
             geometry.x > bounding_box.min_x
             and geometry.x < bounding_box.max_x

--- a/tests/platform/tasks/test_filter_by_geometry_type.py
+++ b/tests/platform/tasks/test_filter_by_geometry_type.py
@@ -1,0 +1,63 @@
+import geopandas as gpd  # type: ignore[import-untyped]
+from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+
+from ecoscope.platform.tasks.transformation import filter_by_geometry_type
+
+
+def _mixed_gdf() -> gpd.GeoDataFrame:
+    poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    multipoly = MultiPolygon([poly, Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])])
+    return gpd.GeoDataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "geometry": [
+                Point(0, 0),
+                Point(1, 1),
+                poly,
+                multipoly,
+                LineString([(0, 0), (1, 1)]),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+
+def test_filter_points():
+    gdf = _mixed_gdf()
+    result = filter_by_geometry_type(gdf, geometry_types=["Point"])
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert list(result["id"].values) == [1, 2]
+    assert (result.geometry.geom_type == "Point").all()
+
+
+def test_filter_polygons_and_multipolygons():
+    gdf = _mixed_gdf()
+    result = filter_by_geometry_type(gdf, geometry_types=["Polygon", "MultiPolygon"])
+    assert list(result["id"].values) == [3, 4]
+    assert set(result.geometry.geom_type) == {"Polygon", "MultiPolygon"}
+
+
+def test_filter_no_match_returns_empty():
+    gdf = _mixed_gdf()
+    result = filter_by_geometry_type(gdf, geometry_types=["GeometryCollection"])
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 0
+
+
+def test_filter_empty_list_returns_empty():
+    gdf = _mixed_gdf()
+    result = filter_by_geometry_type(gdf, geometry_types=[])
+    assert len(result) == 0
+
+
+def test_filter_preserves_crs_and_columns():
+    gdf = _mixed_gdf()
+    result = filter_by_geometry_type(gdf, geometry_types=["Point"])
+    assert result.crs == gdf.crs
+    assert list(result.columns) == list(gdf.columns)
+
+
+def test_filter_on_empty_gdf():
+    gdf = gpd.GeoDataFrame({"id": [], "geometry": []}, crs="EPSG:4326")
+    result = filter_by_geometry_type(gdf, geometry_types=["Point"])
+    assert len(result) == 0

--- a/tests/platform/tasks/test_filtering.py
+++ b/tests/platform/tasks/test_filtering.py
@@ -102,19 +102,13 @@ def test_filter_range_preserves_null_geometry(df_with_geometry):
     pd.testing.assert_frame_equal(filtered_df, expected_df)
 
 
-def test_filter_passes_through_non_point_geometry():
-    polygon = Polygon([(10.0, 10.0), (20.0, 10.0), (20.0, 20.0), (10.0, 20.0), (10.0, 10.0)])
-    df = pd.DataFrame(
-        {
-            "geometry": [
-                Point(0.0, 0.0),
-                polygon,
-            ]
-        }
-    )
+def test_filter_keeps_non_point_geometry_intersecting_bbox():
+    # Polygon overlaps the bounding box (10,10)-(15,15) ∩ (-1,-1)-(1,1) is empty,
+    # but a polygon spanning (-5,-5)-(5,5) does intersect (-1,-1)-(1,1).
+    polygon = Polygon([(-5.0, -5.0), (5.0, -5.0), (5.0, 5.0), (-5.0, 5.0), (-5.0, -5.0)])
+    df = pd.DataFrame({"geometry": [Point(0.0, 0.0), polygon]})
 
-    # BoundingBox excludes the polygon's vertices and centroid; an exact-coord
-    # filter targets the point. Polygon should still survive both.
+    # Exact-coord filter targets the point; polygon should survive on intersect.
     filtered_df = apply_reloc_coord_filter(
         df,
         bounding_box=BoundingBox(min_x=-1.0, max_x=1.0, min_y=-1.0, max_y=1.0),
@@ -123,6 +117,19 @@ def test_filter_passes_through_non_point_geometry():
 
     expected_df = pd.DataFrame({"geometry": [polygon]})
     pd.testing.assert_frame_equal(filtered_df, expected_df)
+
+
+def test_filter_drops_non_point_geometry_disjoint_from_bbox():
+    polygon = Polygon([(10.0, 10.0), (20.0, 10.0), (20.0, 20.0), (10.0, 20.0), (10.0, 10.0)])
+    df = pd.DataFrame({"geometry": [Point(100.0, 50.0), polygon]})
+
+    filtered_df = apply_reloc_coord_filter(
+        df,
+        bounding_box=BoundingBox(min_x=-1.0, max_x=1.0, min_y=-1.0, max_y=1.0),
+    )
+
+    expected_df = pd.DataFrame({"geometry": []})
+    pd.testing.assert_frame_equal(filtered_df, expected_df, check_dtype=False)
 
 
 def test_filter_with_roi(df_with_geometry):

--- a/tests/platform/tasks/test_filtering.py
+++ b/tests/platform/tasks/test_filtering.py
@@ -102,6 +102,29 @@ def test_filter_range_preserves_null_geometry(df_with_geometry):
     pd.testing.assert_frame_equal(filtered_df, expected_df)
 
 
+def test_filter_passes_through_non_point_geometry():
+    polygon = Polygon([(10.0, 10.0), (20.0, 10.0), (20.0, 20.0), (10.0, 20.0), (10.0, 10.0)])
+    df = pd.DataFrame(
+        {
+            "geometry": [
+                Point(0.0, 0.0),
+                polygon,
+            ]
+        }
+    )
+
+    # BoundingBox excludes the polygon's vertices and centroid; an exact-coord
+    # filter targets the point. Polygon should still survive both.
+    filtered_df = apply_reloc_coord_filter(
+        df,
+        bounding_box=BoundingBox(min_x=-1.0, max_x=1.0, min_y=-1.0, max_y=1.0),
+        filter_point_coords=[Coordinate(x=0.0, y=0.0)],
+    )
+
+    expected_df = pd.DataFrame({"geometry": [polygon]})
+    pd.testing.assert_frame_equal(filtered_df, expected_df)
+
+
 def test_filter_with_roi(df_with_geometry):
     expected_df = gpd.GeoDataFrame({"geometry": [Point(0, 0), Point(100, 50)]})
 

--- a/tests/platform/tasks/test_io_earthranger.py
+++ b/tests/platform/tasks/test_io_earthranger.py
@@ -483,6 +483,36 @@ def test_get_events_empty_response(mock_empty_client):
     assert df.empty
 
 
+@pytest.mark.parametrize("force_point_geometry", [True, False])
+def test_get_events_forwards_force_point_geometry(mock_empty_client, force_point_geometry):
+    get_events(
+        client=mock_empty_client,
+        time_range=TimeRange(
+            since=datetime.strptime("2017-01-01", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+            until=datetime.strptime("2017-03-31", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+            timezone=UTC_TIMEZONEINFO,
+        ),
+        event_types=["an_event"],
+        raise_on_empty=False,
+        force_point_geometry=force_point_geometry,
+    )
+    assert mock_empty_client.get_events.call_args.kwargs["force_point_geometry"] is force_point_geometry
+
+
+def test_get_events_force_point_geometry_default_is_true(mock_empty_client):
+    get_events(
+        client=mock_empty_client,
+        time_range=TimeRange(
+            since=datetime.strptime("2017-01-01", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+            until=datetime.strptime("2017-03-31", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+            timezone=UTC_TIMEZONEINFO,
+        ),
+        event_types=["an_event"],
+        raise_on_empty=False,
+    )
+    assert mock_empty_client.get_events.call_args.kwargs["force_point_geometry"] is True
+
+
 def test_get_patrols_empty_response(mock_empty_client):
     kwargs = {
         "client": mock_empty_client,


### PR DESCRIPTION
## Summary

Three backwards-compatible platform task changes to unblock polygon event support in `wt-download-events`:

1. **`get_events`** (`ecoscope/platform/tasks/io/_earthranger.py`): add `force_point_geometry: bool = True` kwarg, forward to `EarthRangerClient.get_events(...)`. Default `True` keeps existing centroid behavior. Workflows can set `False` to preserve native Polygon/MultiPolygon geometries. Also added the kwarg to `EarthRangerClientProtocol` so mypy is happy.
2. **`apply_reloc_coord_filter`** (`ecoscope/platform/tasks/transformation/_filtering.py`): in `envelope_reloc_filter`, handle non-Point geometries explicitly. Without this, a Polygon would AttributeError on `geometry.x`/`.y`. Polygons/MultiPolygons are kept when they intersect the bounding box (via `geometry.intersects(shapely.geometry.box(...))`) and dropped when disjoint. The exact-coord filter remains Point-only since it doesn't apply to areal geometries.
3. **`filter_by_geometry_type`** (new platform task at `ecoscope/platform/tasks/transformation/_filter_by_geometry_type.py`): filters a GeoDataFrame to rows whose `geometry.geom_type` is in a given list. Relocated from `ecoscope-workflow-task-library` (ext-custom) into the platform package so it ships as a built-in transformation, matching the package boundary of the rest of this work.

## Context

All three changes come from the `wt-download-events` polygon-support PRD ("Modified Platform Tasks" section + the new-task entry, which we decided to host in platform rather than ext-custom). They land together because they're co-dependent at the workflow layer, but each is independently backwards-compatible at the library API.

## Test plan

- [x] `pytest tests/platform/tasks/test_io_earthranger.py::test_get_events_forwards_force_point_geometry` (parametrized True/False) — kwarg is forwarded.
- [x] `pytest tests/platform/tasks/test_io_earthranger.py::test_get_events_force_point_geometry_default_is_true` — locks in the default.
- [x] `pytest tests/platform/tasks/test_io_earthranger.py::test_get_events_empty_response` regression — passes.
- [x] `pytest tests/platform/tasks/test_filtering.py::test_filter_keeps_non_point_geometry_intersecting_bbox` — Polygon overlapping the bbox survives; the exact-coord filter does not drop it.
- [x] `pytest tests/platform/tasks/test_filtering.py::test_filter_drops_non_point_geometry_disjoint_from_bbox` — Polygon disjoint from the bbox is dropped.
- [x] `pytest tests/platform/tasks/test_filtering.py` regression — all 8 tests pass.
- [x] `pytest tests/platform/tasks/test_filter_by_geometry_type.py` — 6 tests covering Point/Polygon/MultiPolygon filtering, empty inputs, CRS/columns preservation.
- [x] `mypy ecoscope/platform/tasks/io/_earthranger.py ecoscope/platform/connections.py ecoscope/platform/tasks/transformation/...` clean.
- [x] Downstream: `wt-download-events` will exercise `force_point_geometry: false` and the new `filter_by_geometry_type` end-to-end via its spec once this is released.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)