### PR TITLE
fix(earthranger): fall back gracefully when event_type missing from registry

### DIFF
--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -842,6 +842,11 @@ class EarthRangerIO(ERClient):
             If set to duplicates, the event category value will be appended
                 only for event types with overlapping display names
             If set to never, no category names will be appended
+
+        Event types that are present on events but missing from the ER
+        event-type registry (e.g. deleted/orphan types still attached to
+        historical events) fall back to their raw event_type value as the
+        display, rather than raising KeyError.
         Returns
         -------
         gpd.GeoDataFrame

--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -850,7 +850,9 @@ class EarthRangerIO(ERClient):
 
         event_types = self.get_event_types(include_inactive=True)
         event_type_lookup = dict(zip(event_types["value"], event_types["display"]))
-        events_gdf["event_type_display"] = events_gdf["event_type"].map(lambda x: event_type_lookup[x])
+        events_gdf["event_type_display"] = (
+            events_gdf["event_type"].map(event_type_lookup).fillna(events_gdf["event_type"])
+        )
 
         has_duplicates = len(events_gdf["event_type_display"].unique()) != len(events_gdf["event_type"].unique())
         do_append = append_category_names == "always" or (append_category_names == "duplicates" and has_duplicates)

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -839,6 +839,33 @@ def test_get_event_type_display_names_from_events_categories_duplicates_only(er_
     assert "Inactive Event" in events["event_type_display"].unique()
 
 
+def test_get_event_type_display_names_from_events_falls_back_for_unknown_type(er_events_io):
+    # Event types attached to historical events are sometimes absent from the ER
+    # event-type registry (e.g., deleted types). The function must fall back to
+    # the raw event_type value rather than raising KeyError.
+    events_gdf = gpd.GeoDataFrame(
+        {
+            "event_type": ["accident", "orphan_event_type"],
+            "geometry": [Point(0, 0), Point(1, 1)],
+        },
+        crs=4326,
+    )
+    registry = pd.DataFrame(
+        {
+            "value": ["accident"],
+            "display": ["Accident"],
+            "category": [{"value": "security", "display": "Security"}],
+        }
+    )
+    with patch.object(er_events_io, "get_event_types", return_value=registry):
+        result = er_events_io.get_event_type_display_names_from_events(
+            events_gdf=events_gdf,
+            append_category_names="never",
+        )
+
+    assert list(result["event_type_display"]) == ["Accident", "orphan_event_type"]
+
+
 def test_get_event_type_display_names_from_patrol_events(er_events_io):
     patrol_events = er_events_io.get_patrol_events(
         since=pd.Timestamp("2017-01-01").isoformat(),


### PR DESCRIPTION
## Summary
- `EarthRangerIO.get_event_type_display_names_from_events` raised `KeyError` when an event's `event_type` was absent from `get_event_types(include_inactive=True)` (e.g. orphaned/deleted types still attached to historical events).
- Mirror the `Series.map(dict)` pattern already used a few lines below for the category lookup, then `fillna` with the raw `event_type` so the column stays non-null and downstream groupby/counts behave.
- Add a unit test that mocks `get_event_types` to exercise the missing-key path deterministically.
- Update the docstring to note the fallback behavior.

Originally surfaced by a `wg-encounter-rate` live run on the [encounter-rate workflow](https://github.com/wildlife-dynamics/ecoscope-workflows-encounter-rate) (`KeyError: 'test_wildlife_sighting'`), which crashed the downstream pipeline.

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)