### PR TITLE
Harden publish.yml gating to check `wt-registry` cli works as a PR check, and bump pandera + io-core to fix broken `wt-registry` call

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc"
     branches:
       - "master"
+  pull_request:
 
 env:
   PYTHON_VERSION: "3.10.12"
@@ -60,6 +61,7 @@ jobs:
     needs:
     - build
     - install
+    - publish-to-prefix
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -101,7 +103,6 @@ jobs:
     - build
     - install
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v6
       - name: Download the built dist
@@ -110,7 +111,13 @@ jobs:
           name: pip-dist
           path: dist/
       - name: Add tag to recipe
-        run: sed -i "s/TAG_VERSION/${GITHUB_REF_NAME#v}/g" publish/recipes/release/ecoscope.yaml
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="0.0.0.dev0"
+          fi
+          sed -i "s/TAG_VERSION/${VERSION}/g" publish/recipes/release/ecoscope.yaml
       - name: Add dist to recipe
         run: sed -i "s/DIST_NAME/$(find ./dist/*.tar.gz  -printf "%f\n")/g" publish/recipes/release/ecoscope.yaml
       - name: Log the generated recipe
@@ -122,7 +129,33 @@ jobs:
         with:
           recipe-path: publish/recipes/release/ecoscope.yaml
           build-args: --output-dir /tmp/ecoscope/release/artifacts --channel https://prefix.dev/ecoscope-workflows --channel conda-forge
-      - run: |
+      - name: Upload built conda artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: prefix-conda
+          path: /tmp/ecoscope/release/artifacts/**/*.conda
+
+  publish-to-prefix:
+    name: Publish prefix package
+    needs:
+    - build-for-prefix
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download built conda artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: prefix-conda
+          path: /tmp/ecoscope/release/artifacts
+      - name: Install rattler-build
+        run: |
+          curl -L -o "${HOME}/.local/bin/rattler-build" \
+            https://github.com/prefix-dev/rattler-build/releases/latest/download/rattler-build-x86_64-unknown-linux-musl
+          chmod +x "${HOME}/.local/bin/rattler-build"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+      - name: Upload to prefix.dev
+        run: |
           for file in /tmp/ecoscope/release/artifacts/**/*.conda; do
             rattler-build upload prefix -c ecoscope-workflows "$file"
           done

--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -79,7 +79,7 @@ outputs:
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
         - pydeck ==0.9.2
-        - ecoscope-earthranger-io-core ==0.0.12
+        - ecoscope-earthranger-io-core ==0.0.14
     tests:
       - python:
           imports:

--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -72,7 +72,7 @@ outputs:
     requirements:
       run:
         - ecoscope ==${{ version }}
-        - pandera >=0.24.0,<0.29
+        - pandera >=0.28,<0.29
         - pydantic <2.9.0
         - pydantic-settings
         - cloudpathlib-gs

--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -79,7 +79,7 @@ outputs:
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
         - pydeck ==0.9.2
-        - ecoscope-earthranger-io-core ==0.0.11
+        - ecoscope-earthranger-io-core ==0.0.12
     tests:
       - python:
           imports:

--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -84,6 +84,9 @@ outputs:
       - python:
           imports:
             - ecoscope.platform
+      - script: |
+          wt-registry --package ecoscope.platform.tasks --format json \
+            | python -c "import json, sys; data = json.load(sys.stdin); assert data, 'wt-registry returned empty result'"
 
 about:
   summary: Standard Analytical Reporting Framework for Conservation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.12",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.14",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ mapping = [
 ]
 plotting = ["plotly", "scikit-learn"]
 platform = [
-    "pandera>=0.24.0,<0.29",
+    "pandera>=0.28,<0.29",
     "pydantic<2.9.0",  # >=2.9 breaks discriminated unions in apply_classification (duplicate 'equal_interval' key)
     "pydantic-settings",
     "cloudpathlib[gs]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.11",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.12",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",


### PR DESCRIPTION


## :earth_americas: Summary

closes #702

## :package: Proposed Changes

- Split build-for-prefix into build-only and publish-to-prefix jobs; build now runs on pull_request so recipe breakage is caught at PR time.
- Make github-release depend on publish-to-prefix so a failed prefix upload blocks the GH release, keeping GH and prefix.dev in sync.
- Add a wt-registry --format json script test to the ecoscope-platform recipe output to guard against entry-point regressions.

## 🔬 Verification

- Note that the compiler error reported in #702 was initially reproduced in https://github.com/wildlife-dynamics/ecoscope/actions/runs/25838427138/job/75918494073#step:8:2177
- The fix for this was raising the pandera lower bound to 0.28 for numpy compat, and this in turn required raising the io-core lower bound (to accomodate the higher pandera)
- With those changes made, the build test check called out in https://github.com/wildlife-dynamics/ecoscope/pull/701#discussion_r3238998908 is now passing https://github.com/wildlife-dynamics/ecoscope/actions/runs/25840708716/job/75925226153

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary