### PR TITLE
DWH parity for exclusion_flags and patrols_overlap_daterange (ERDW-210)

### DIFF
--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -441,13 +441,14 @@ def get_subjectgroup_observations(
     """Get observations for a subject group from EarthRanger."""
     from ecoscope.relocations import Relocations
 
+    filter_int = _EXCLUSION_FILTER_TO_INT[filter]
+
     if warehouse_client := _make_warehouse_client_from_env(
         er_site_url=client.server,
         er_api_token=SecretStr(client.token) if client.token else None,
     ):
         import geopandas as gpd  # type: ignore[import-untyped]
 
-        logger.warning("Exclusion flags filter is not yet supported by the warehouse API and will be ignored")
         table = warehouse_client.get_subjectgroup_observations(
             subject_group_name=subject_group_name,
             include_subject_details=True,
@@ -456,11 +457,10 @@ def get_subjectgroup_observations(
             include_subjectsource_details=include_subjectsource_details,
             since=time_range.since.isoformat(),
             until=time_range.until.isoformat(),
-            # TODO: pass exclusion flags filter once supported in the DWH API
+            filter=filter_int,
         )
         subject_group_obs_relocs = gpd.GeoDataFrame.from_arrow(table)
     else:
-        filter_int = _EXCLUSION_FILTER_TO_INT[filter]
         subject_group_obs_relocs = client.get_subjectgroup_observations(
             subject_group_name=subject_group_name,
             include_subject_details=True,
@@ -503,11 +503,6 @@ def get_patrol_observations(
     ):
         import geopandas as gpd  # type: ignore[import-untyped]
 
-        if not patrols_overlap_daterange:
-            logger.warning(
-                "patrols_overlap_daterange=False is not yet supported by the warehouse API; "
-                "overlap semantics will be used"
-            )
         table = warehouse_client.get_patrol_observations_with_patrol_filter(
             since=time_range.since.isoformat(),
             until=time_range.until.isoformat(),
@@ -515,8 +510,7 @@ def get_patrol_observations(
             status=status,
             include_patrol_details=include_patrol_details,
             sub_page_size=sub_page_size,
-            # TODO: pass patrols_overlap_daterange once the warehouse API supports it;
-            # currently the API always uses overlap semantics (equivalent to True).
+            patrols_overlap_daterange=patrols_overlap_daterange,
         )
         patrol_obs_relocs = gpd.GeoDataFrame.from_arrow(table)
     else:
@@ -740,8 +734,6 @@ def get_patrol_observations_from_patrols_df(
             patrols_df=patrols_df,
             include_patrol_details=include_patrol_details,
             sub_page_size=sub_page_size,
-            # TODO: pass patrols_overlap_daterange once the warehouse API supports it;
-            # currently the API always uses overlap semantics (equivalent to True).
         )
         patrol_obs_relocs = gpd.GeoDataFrame.from_arrow(table)
     else:

--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -79,7 +79,7 @@ outputs:
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
         - pydeck ==0.9.2
-        - ecoscope-earthranger-io-core ==0.0.14
+        - ecoscope-earthranger-io-core ==0.0.16
     tests:
       - python:
           imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.14",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.16",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",

--- a/tests/platform/tasks/test_io_earthranger.py
+++ b/tests/platform/tasks/test_io_earthranger.py
@@ -1263,6 +1263,16 @@ def test_get_patrol_observations_via_warehouse_client():
 
     mock_warehouse_client.get_patrol_observations_with_patrol_filter.assert_called_once()
     mock_legacy_client.get_patrol_observations_with_patrol_filter.assert_not_called()
+    call_kwargs = mock_warehouse_client.get_patrol_observations_with_patrol_filter.call_args.kwargs
+    assert call_kwargs == {
+        "since": "2024-01-01T00:00:00+00:00",
+        "until": "2024-03-01T00:00:00+00:00",
+        "patrol_type_value": ["routine_patrol"],
+        "status": ["done"],
+        "include_patrol_details": True,
+        "sub_page_size": 100,
+        "patrols_overlap_daterange": True,
+    }
     assert isinstance(result, gpd.GeoDataFrame)
     assert "geometry" in result
     assert "patrol_type__value" in result
@@ -1286,9 +1296,76 @@ def test_get_patrol_observations_from_patrols_df_via_warehouse_client():
 
     mock_warehouse_client.get_patrol_observations.assert_called_once()
     mock_legacy_client.get_patrol_observations.assert_not_called()
+    call_kwargs = mock_warehouse_client.get_patrol_observations.call_args.kwargs
+    assert set(call_kwargs.keys()) == {"patrols_df", "include_patrol_details", "sub_page_size"}
+    assert call_kwargs["include_patrol_details"] is True
+    assert call_kwargs["sub_page_size"] == 100
+    assert call_kwargs["patrols_df"] is patrols_df
     assert isinstance(result, gpd.GeoDataFrame)
     assert "geometry" in result
     assert "patrol_type__value" in result
+
+
+@pytest.mark.parametrize(
+    "filter_value, expected_int",
+    list(_EXCLUSION_FILTER_TO_INT.items()),
+)
+def test_get_subjectgroup_observations_via_warehouse_client_forwards_filter(filter_value, expected_int):
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_subjectgroup_observations.return_value = _make_observations_arrow_table()
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        get_subjectgroup_observations(
+            client=mock_legacy_client,
+            subject_group_name="Ecoscope",
+            time_range=TimeRange(
+                since=datetime.strptime("2024-01-01", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+                until=datetime.strptime("2024-03-01", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+                timezone=UTC_TIMEZONEINFO,
+            ),
+            raise_on_empty=False,
+            filter=filter_value,
+        )
+
+    mock_warehouse_client.get_subjectgroup_observations.assert_called_once()
+    mock_legacy_client.get_subjectgroup_observations.assert_not_called()
+    assert mock_warehouse_client.get_subjectgroup_observations.call_args.kwargs["filter"] == expected_int
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_get_patrol_observations_via_warehouse_client_forwards_patrols_overlap_daterange(value):
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_patrol_observations_with_patrol_filter.return_value = (
+        _make_patrol_observations_arrow_table()
+    )
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        get_patrol_observations(
+            client=mock_legacy_client,
+            time_range=TimeRange(
+                since=datetime.strptime("2024-01-01", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+                until=datetime.strptime("2024-03-01", "%Y-%m-%d").replace(tzinfo=timezone.utc),
+                timezone=UTC_TIMEZONEINFO,
+            ),
+            patrol_types=["routine_patrol"],
+            raise_on_empty=False,
+            patrols_overlap_daterange=value,
+        )
+
+    mock_warehouse_client.get_patrol_observations_with_patrol_filter.assert_called_once()
+    mock_legacy_client.get_patrol_observations_with_patrol_filter.assert_not_called()
+    assert (
+        mock_warehouse_client.get_patrol_observations_with_patrol_filter.call_args.kwargs["patrols_overlap_daterange"]
+        == value
+    )
 
 
 def test_warehouse_disabled_falls_back_to_legacy_client():


### PR DESCRIPTION
## :earth_americas: Summary
Closes #708
Closes the parity gap between the legacy `EarthRangerIO` branch and the `ERWarehouseClient` in Ecoscope tasks: both now receive `exclusion_flags` (via filter) and `patrols_overlap_daterange` identically. Bumps `ecoscope-earthranger-io-core` `v0.0.14 → v0.0.16` (the release that exposes both kwargs on the DWH client).

## :package: Proposed Changes
- `ecoscope/platform/tasks/io/_earthranger.py`
    - `get_subjectgroup_observations`: forward `filter=filter_int` to the warehouse client; drop the "not yet supported" warning + TODO.
    - `get_patrol_observations`: forward `patrols_overlap_daterange` to the warehouse client; drop the False-only warning + TODO.
    - `get_patrol_observations_from_patrols_df`: remove stale TODO (no functional change — task signature has neither param).
  
- Pin bump` v0.0.14 → v0.0.16` in both `pyproject.toml` and `publish/recipes/release/ecoscope.yaml `(conda recipe).

### Tests
  - New `test_get_subjectgroup_observations_via_warehouse_client_forwards_filter` — parametrized across `_EXCLUSION_FILTER_TO_INT`, asserts filter kwarg reaches the DWH client.
  - New `test_get_patrol_observations_via_warehouse_client_forwards_patrols_overlap_daterange` — parametrized over [True, False], regression guard for the gap closed here.
  - Tightened the two existing warehouse-branch tests to assert full kwarg dicts so future param drops fail loudly.


## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary