### PR TITLE
fix(analysis): coerce unresolved sun_time rise/set to NaT

### DIFF
--- a/ecoscope/analysis/astronomy.py
+++ b/ecoscope/analysis/astronomy.py
@@ -83,6 +83,15 @@ def sun_time(date: datetime, geometry: BaseGeometry) -> pd.Series:
     observer = astroplan.Observer(location=EarthLocation(lon=geometry.centroid.x, lat=geometry.centroid.y))
     sunrise = observer.sun_rise_time(midnight, which="next", n_grid_points=150).to_datetime(timezone=pytz.UTC)
     sunset = observer.sun_set_time(midnight, which="next", n_grid_points=150).to_datetime(timezone=pytz.UTC)
+    # astroplan returns a masked 0-d array when it cannot bracket the event within its
+    # bounded forward search window (e.g. mid-latitude days where the "next" sunrise/sunset
+    # falls at the window edge, or polar day/night). Coerce to NaT so the day is dropped from
+    # the night/day ratio instead of crashing the downstream Timestamp comparisons in
+    # calculate_day_fraction with "iteration over a 0-d array".
+    if not isinstance(sunrise, datetime):
+        sunrise = pd.NaT
+    if not isinstance(sunset, datetime):
+        sunset = pd.NaT
     return pd.Series({"sunrise": sunrise, "sunset": sunset})
 
 

--- a/tests/test_astronomy.py
+++ b/tests/test_astronomy.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pyproj
 import pytest
+from shapely.geometry import Point
 
 from ecoscope import Trajectory
 from ecoscope.analysis import astronomy
@@ -289,3 +290,13 @@ def test_calculate_day_fraction_vectorized():
         segment_end=pd.Series(ends),
     )
     np.testing.assert_allclose(actual, expected)
+
+
+def test_sun_time_unresolved_returns_nat():
+    # At a polar-day latitude the sun never sets within astroplan's search window, so
+    # astroplan returns a masked 0-d value. sun_time must coerce it to NaT rather than
+    # passing the 0-d array through, which would later crash get_nightday_ratio with
+    # "iteration over a 0-d array" during the calculate_day_fraction comparisons.
+    result = astronomy.sun_time(datetime(2025, 6, 21), Point(0.0, 80.0))
+    assert pd.isna(result["sunrise"])
+    assert pd.isna(result["sunset"])


### PR DESCRIPTION
## Summary
- `ecoscope.analysis.astronomy.sun_time` now coerces a masked/unresolved sunrise or sunset to `NaT` instead of returning astroplan's masked 0-d array.
- Adds a regression test (`test_sun_time_unresolved_returns_nat`) using a polar-day latitude — a deterministic trigger of the masked path.

## Why
astroplan's `sun_rise_time`/`sun_set_time` return a masked 0-d array when they can't bracket the event within their bounded forward search window — e.g. mid/high-latitude days where the "next" sunrise/sunset lands at the window edge, or true polar day/night. That 0-d value then crashes `get_nightday_ratio`'s vectorized Timestamp comparisons in `calculate_day_fraction` with `TypeError: iteration over a 0-d array`. Because `gather_dashboard` skips on any failed dependency, a single such day takes down the **entire** subject-tracking dashboard for non-equatorial data (e.g. a Mongolian snow-leopard dataset hit it on ~4 days/year). Equatorial demo data never lands in that regime, so it had gone unnoticed.

## Behavior change
Minimal and non-regressive: only days where rise/set is genuinely unresolvable change — they drop out of the night/day ratio (consistent with the existing `.dropna()` in `get_nightday_ratio`). Every other day, including all equatorial data, is byte-for-byte identical, so existing snapshots are unaffected.

## Test plan
- [x] `mypy ecoscope` — no errors in the changed module
- [x] `pytest tests/test_astronomy.py` — 26 passed (incl. new regression test + unchanged `test_nightday_ratio`)

Closes #722
