### PR TITLE
CSS fix for light mode link styles in sdk docs

### DIFF
--- a/doc/platform-sdk/content/stylesheets/extra.css
+++ b/doc/platform-sdk/content/stylesheets/extra.css
@@ -28,6 +28,20 @@
   --md-default-bg-color--light: #163a3c;
 }
 
+/* The theme sets --md-typeset-a-color via a two-attribute selector
+   ([scheme][primary] -> #5488e8), which outranks a scheme-only rule. Match
+   that specificity to override it once; this single variable drives both
+   body link color and the active nav item, and hover still falls back to
+   --md-accent-fg-color via the theme's own a:hover rule. */
+[data-md-color-scheme="slate"][data-md-color-primary] {
+  --md-typeset-a-color: #0FCB8C;
+}
+
+/* Underline body links in dark mode for clear distinction from text */
+[data-md-color-scheme="slate"] .md-typeset a:not(.headerlink) {
+  text-decoration: underline;
+}
+
 /* Remove the outer mkdocstrings container "card" */
 .md-typeset .doc.doc-object.doc-module {
   border: none;

--- a/doc/platform-sdk/content/stylesheets/extra.css
+++ b/doc/platform-sdk/content/stylesheets/extra.css
@@ -8,6 +8,12 @@
   --md-default-fg-color--light: #2a6b6b;
   --md-default-bg-color: #f5ece0;
   --md-default-bg-color--light: #faf6f0;
+  --md-typeset-a-color: #105257;
+}
+
+/* Underline body links in light mode for clear distinction from text */
+[data-md-color-scheme="default"] .md-typeset a:not(.headerlink) {
+  text-decoration: underline;
 }
 
 /* Dark mode — Dark Teal + Off White/Green */


### PR DESCRIPTION
## :earth_americas: Summary

closes #723

## :package: Proposed Changes

- Implements fix per @tiffanynwong's styling recommendations

## 📋 Checklist
~~- [ ] Corresponding ecoscope.platform tasks updated if necessary~~