### PR TITLE
Fix nightday_ratio

### DIFF
--- a/ecoscope/analysis/astronomy.py
+++ b/ecoscope/analysis/astronomy.py
@@ -168,7 +168,8 @@ def calculate_day_fraction(
 
 
 def get_nightday_ratio(gdf: gpd.GeoDataFrame) -> float:
-    gdf["date"] = pd.to_datetime(gdf["segment_start"]).dt.date
+    # Ensure UTC here so each date lines up with the UTC midnight reference used by sun_time
+    gdf["date"] = gdf["segment_start"].dt.tz_convert("UTC").dt.date
 
     daily_summary = gdf.groupby("date").first()["geometry"].reset_index()
     daily_summary[["sunrise", "sunset"]] = daily_summary.apply(lambda x: sun_time(x.date, x.geometry), axis=1)

--- a/tests/test_astronomy.py
+++ b/tests/test_astronomy.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pandas as pd
@@ -45,7 +45,15 @@ def test_is_night(movebank_relocations):
     assert subset["is_night"].values.tolist() == [True, True, False]
 
 
-def test_nightday_ratio(movebank_relocations):
+@pytest.mark.parametrize(
+    "timezone",
+    [
+        timezone(timedelta(hours=5)),
+        timezone.utc,
+        timezone(timedelta(hours=-5)),
+    ],
+)
+def test_nightday_ratio(movebank_relocations, timezone):
     # movebank_relocations is subsampled to keep execution speed low.
     # Expected ratios for the full data are:
     # Habiba=0.45905845612291696, Salif Keita=2.0019632541788472.
@@ -56,6 +64,7 @@ def test_nightday_ratio(movebank_relocations):
         [0.3736601604553539, 2.1840195829850435],
         index=pd.Index(["Habiba", "Salif Keita"], name="groupby_col"),
     )
+    trajectory.gdf["segment_start"] = trajectory.gdf["segment_start"].dt.tz_convert(timezone).dt.as_unit("ns")
     pd.testing.assert_series_equal(
         trajectory.gdf.groupby("groupby_col")[trajectory.gdf.columns].apply(
             astronomy.get_nightday_ratio, include_groups=False

--- a/tests/test_astronomy.py
+++ b/tests/test_astronomy.py
@@ -48,9 +48,9 @@ def test_is_night(movebank_relocations):
 @pytest.mark.parametrize(
     "timezone",
     [
-        timezone(timedelta(hours=5)),
+        timezone(timedelta(hours=10)),
         timezone.utc,
-        timezone(timedelta(hours=-5)),
+        timezone(timedelta(hours=-6)),
     ],
 )
 def test_nightday_ratio(movebank_relocations, timezone):
@@ -64,6 +64,7 @@ def test_nightday_ratio(movebank_relocations, timezone):
         [0.3736601604553539, 2.1840195829850435],
         index=pd.Index(["Habiba", "Salif Keita"], name="groupby_col"),
     )
+    # test against a handful of timezone to ensure this calculation is agnotisc of input timezone
     trajectory.gdf["segment_start"] = trajectory.gdf["segment_start"].dt.tz_convert(timezone).dt.as_unit("ns")
     pd.testing.assert_series_equal(
         trajectory.gdf.groupby("groupby_col")[trajectory.gdf.columns].apply(


### PR DESCRIPTION
## :earth_americas: Summary
Closes #725 

## :package: Proposed Changes
Coerces the summary date bins in `get_nightday_ratio` to UTC, to match `sun_time` which assumes UTC dates

## 📋 Checklist
- [ ] ~~Corresponding ecoscope.platform tasks updated if necessary~~