### PR TITLE
Second nightday_ratio fix

### DIFF
--- a/ecoscope/analysis/astronomy.py
+++ b/ecoscope/analysis/astronomy.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pyproj
 import pytz
+import shapely
 from shapely.geometry.base import BaseGeometry
 
 try:
@@ -80,6 +81,8 @@ def sun_time(date: datetime, geometry: BaseGeometry) -> pd.Series:
     """
     Sunrise and sunset of the local solar day labelled by `date` at `geometry`.
     Returned timestamps are in UTC, representing the UTC time of the local sunrise/sunset.
+
+    The `geometry` provided is assumed to be in EPSG:4326 (WGS84 lon/lat)
     """
     centroid = geometry.centroid
     offset = timedelta(hours=centroid.x / 15.0)
@@ -173,13 +176,23 @@ def calculate_day_fraction(
 
 
 def get_nightday_ratio(gdf: gpd.GeoDataFrame) -> float:
-    lon = gdf["geometry"].to_crs(4326).centroid.x
+    start_points = gpd.GeoSeries(
+        shapely.get_point(gdf["geometry"].values, 0),
+        crs=gdf.crs,
+        index=gdf.index,
+    ).to_crs(4326)
 
     # Bin by local solar date to prevent UTC timestamps straddling local night -> day
-    offset = pd.to_timedelta(lon / 15.0, unit="h")
+    # NOTE: this calculation will skew if tracks cross the -180, 180 boundary
+    offset = pd.to_timedelta(start_points.x / 15.0, unit="h")
     gdf["local_date"] = (gdf["segment_start"].dt.tz_convert("UTC").dt.tz_localize(None) + offset).dt.date
 
-    daily_summary = gdf.groupby("local_date").first()["geometry"].reset_index()
+    daily_summary = (
+        pd.DataFrame({"local_date": gdf["local_date"].values, "geometry": start_points.values})
+        .groupby("local_date")
+        .first()
+        .reset_index()
+    )
     daily_summary[["sunrise", "sunset"]] = daily_summary.apply(lambda x: sun_time(x.local_date, x.geometry), axis=1)
     daily_summary = daily_summary.set_index("local_date")
 

--- a/ecoscope/analysis/astronomy.py
+++ b/ecoscope/analysis/astronomy.py
@@ -79,16 +79,12 @@ def is_night(
 def sun_time(date: datetime, geometry: BaseGeometry) -> pd.Series:
     """
     Sunrise and sunset of the local solar day labelled by `date` at `geometry`.
-
-    `date` is the local solar date — the UTC offset is derived from longitude
-    (lon / 15 h), not a political timezone. Anchoring the search at local solar
-    noon and asking for the previous sunrise + next sunset guarantees both
-    events lie on the same local day even when local midnight straddles UTC
-    midnight, which is the failure mode when binning by UTC date.
+    Returned timestamps are in UTC, representing the UTC time of the local sunrise/sunset.
     """
     centroid = geometry.centroid
     offset = timedelta(hours=centroid.x / 15.0)
     local_noon_utc = datetime(date.year, date.month, date.day, 12) - offset
+    # Anchoring the search at local solar noon guarantees both events lie on the same local day
     anchor = Time(local_noon_utc, scale="utc")
     observer = astroplan.Observer(location=EarthLocation(lon=centroid.x, lat=centroid.y))
     sunrise = observer.sun_rise_time(anchor, which="previous", n_grid_points=150).to_datetime(timezone=pytz.UTC)
@@ -177,24 +173,19 @@ def calculate_day_fraction(
 
 
 def get_nightday_ratio(gdf: gpd.GeoDataFrame) -> float:
-    # Bin by local solar date (UTC offset = lon / 15 h) so each row is matched
-    # against the sunrise/sunset of the local day its segment actually sits in.
-    # Binning by UTC date mismatches cross-midnight segments at non-zero
-    # longitudes against rise/set events from the adjacent local day, which
-    # stretches day or night sections.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Geometry is in a geographic CRS.", UserWarning)
-        lon = gdf["geometry"].to_crs(4326).centroid.x
-    offset = pd.to_timedelta(lon / 15.0, unit="h")
-    gdf["date"] = (gdf["segment_start"].dt.tz_convert("UTC").dt.tz_localize(None) + offset).dt.date
+    lon = gdf["geometry"].to_crs(4326).centroid.x
 
-    daily_summary = gdf.groupby("date").first()["geometry"].reset_index()
-    daily_summary[["sunrise", "sunset"]] = daily_summary.apply(lambda x: sun_time(x.date, x.geometry), axis=1)
-    daily_summary = daily_summary.set_index("date")
+    # Bin by local solar date to prevent UTC timestamps straddling local night -> day
+    offset = pd.to_timedelta(lon / 15.0, unit="h")
+    gdf["local_date"] = (gdf["segment_start"].dt.tz_convert("UTC").dt.tz_localize(None) + offset).dt.date
+
+    daily_summary = gdf.groupby("local_date").first()["geometry"].reset_index()
+    daily_summary[["sunrise", "sunset"]] = daily_summary.apply(lambda x: sun_time(x.local_date, x.geometry), axis=1)
+    daily_summary = daily_summary.set_index("local_date")
 
     day_fraction = calculate_day_fraction(
-        sunrise=gdf["date"].map(daily_summary["sunrise"]),
-        sunset=gdf["date"].map(daily_summary["sunset"]),
+        sunrise=gdf["local_date"].map(daily_summary["sunrise"]),
+        sunset=gdf["local_date"].map(daily_summary["sunset"]),
         segment_start=gdf["segment_start"],
         segment_end=gdf["segment_end"],
     )
@@ -202,8 +193,12 @@ def get_nightday_ratio(gdf: gpd.GeoDataFrame) -> float:
     day_dist = day_fraction * gdf["dist_meters"]
     night_dist = (1 - day_fraction) * gdf["dist_meters"]
 
-    daily_summary["day_distance"] = day_dist.groupby(gdf["date"]).sum().reindex(daily_summary.index, fill_value=0.0)
-    daily_summary["night_distance"] = night_dist.groupby(gdf["date"]).sum().reindex(daily_summary.index, fill_value=0.0)
+    daily_summary["day_distance"] = (
+        day_dist.groupby(gdf["local_date"]).sum().reindex(daily_summary.index, fill_value=0.0)
+    )
+    daily_summary["night_distance"] = (
+        night_dist.groupby(gdf["local_date"]).sum().reindex(daily_summary.index, fill_value=0.0)
+    )
 
     daily_summary["night_day_ratio"] = daily_summary["night_distance"] / daily_summary["day_distance"]
     mean_night_day_ratio = daily_summary["night_day_ratio"].replace([np.inf, -np.inf], np.nan).dropna().mean()

--- a/ecoscope/analysis/astronomy.py
+++ b/ecoscope/analysis/astronomy.py
@@ -77,15 +77,24 @@ def is_night(
 
 
 def sun_time(date: datetime, geometry: BaseGeometry) -> pd.Series:
-    midnight = Time(
-        datetime(date.year, date.month, date.day) + timedelta(seconds=1), scale="utc"
-    )  # add 1 second shift to avoid leap_second_strict warning
-    observer = astroplan.Observer(location=EarthLocation(lon=geometry.centroid.x, lat=geometry.centroid.y))
-    sunrise = observer.sun_rise_time(midnight, which="next", n_grid_points=150).to_datetime(timezone=pytz.UTC)
-    sunset = observer.sun_set_time(midnight, which="next", n_grid_points=150).to_datetime(timezone=pytz.UTC)
+    """
+    Sunrise and sunset of the local solar day labelled by `date` at `geometry`.
+
+    `date` is the local solar date — the UTC offset is derived from longitude
+    (lon / 15 h), not a political timezone. Anchoring the search at local solar
+    noon and asking for the previous sunrise + next sunset guarantees both
+    events lie on the same local day even when local midnight straddles UTC
+    midnight, which is the failure mode when binning by UTC date.
+    """
+    centroid = geometry.centroid
+    offset = timedelta(hours=centroid.x / 15.0)
+    local_noon_utc = datetime(date.year, date.month, date.day, 12) - offset
+    anchor = Time(local_noon_utc, scale="utc")
+    observer = astroplan.Observer(location=EarthLocation(lon=centroid.x, lat=centroid.y))
+    sunrise = observer.sun_rise_time(anchor, which="previous", n_grid_points=150).to_datetime(timezone=pytz.UTC)
+    sunset = observer.sun_set_time(anchor, which="next", n_grid_points=150).to_datetime(timezone=pytz.UTC)
     # astroplan returns a masked 0-d array when it cannot bracket the event within its
-    # bounded forward search window (e.g. mid-latitude days where the "next" sunrise/sunset
-    # falls at the window edge, or polar day/night). Coerce to NaT so the day is dropped from
+    # bounded search window (polar day/night). Coerce to NaT so the day is dropped from
     # the night/day ratio instead of crashing the downstream Timestamp comparisons in
     # calculate_day_fraction with "iteration over a 0-d array".
     if not isinstance(sunrise, datetime):
@@ -168,8 +177,16 @@ def calculate_day_fraction(
 
 
 def get_nightday_ratio(gdf: gpd.GeoDataFrame) -> float:
-    # Ensure UTC here so each date lines up with the UTC midnight reference used by sun_time
-    gdf["date"] = gdf["segment_start"].dt.tz_convert("UTC").dt.date
+    # Bin by local solar date (UTC offset = lon / 15 h) so each row is matched
+    # against the sunrise/sunset of the local day its segment actually sits in.
+    # Binning by UTC date mismatches cross-midnight segments at non-zero
+    # longitudes against rise/set events from the adjacent local day, which
+    # stretches day or night sections.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Geometry is in a geographic CRS.", UserWarning)
+        lon = gdf["geometry"].to_crs(4326).centroid.x
+    offset = pd.to_timedelta(lon / 15.0, unit="h")
+    gdf["date"] = (gdf["segment_start"].dt.tz_convert("UTC").dt.tz_localize(None) + offset).dt.date
 
     daily_summary = gdf.groupby("date").first()["geometry"].reset_index()
     daily_summary[["sunrise", "sunset"]] = daily_summary.apply(lambda x: sun_time(x.date, x.geometry), axis=1)

--- a/tests/platform/tasks/test_summary.py
+++ b/tests/platform/tasks/test_summary.py
@@ -94,4 +94,4 @@ def test_summarize_df_night_day_ratio(trajectories):
     ]
     result = summarize_df(trajectories, summary_params)
     assert result.loc[0, "Total Dist Km"] == 2242.49
-    assert result.loc[0, "Night Day Ratio"] == 1.03
+    assert result.loc[0, "Night Day Ratio"] == 1.02

--- a/tests/test_astronomy.py
+++ b/tests/test_astronomy.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timedelta, timezone
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pyproj
 import pytest
-from shapely.geometry import Point
+from shapely.geometry import LineString, Point
 
 from ecoscope import Trajectory
 from ecoscope.analysis import astronomy
@@ -53,7 +54,7 @@ def test_is_night(movebank_relocations):
         timezone(timedelta(hours=-6)),
     ],
 )
-def test_nightday_ratio(movebank_relocations, timezone):
+def test_nightday_ratio_salif_habiba(movebank_relocations, timezone):
     # movebank_relocations is subsampled to keep execution speed low.
     # Expected ratios for the full data are:
     # Habiba=0.4546939436509577, Salif Keita=2.0114194855402805.
@@ -72,6 +73,30 @@ def test_nightday_ratio(movebank_relocations, timezone):
         ),
         expected,
     )
+
+
+@pytest.mark.parametrize("lon", [0.0, 60.0, 120.0, -60.0, -120.0, 23.0, -77.0])
+def test_nightday_ratio_synthetic_baseline(lon):
+    # Place two segments at clear local-night times and two at clear local-day times;
+    # the calculated ratio should always be 1.0.
+    # For non-zero longitudes the segments straddle two UTC dates, so this also
+    # ensures we're agnostic of UTC date boundaries.
+    utc_midnight = pd.Timestamp("2024-03-20", tz="UTC")
+    offset = pd.Timedelta(hours=lon / 15.0)
+    local_hours = [2, 12, 13, 22]  # two clearly-night, two clearly-day
+    starts = [utc_midnight + pd.Timedelta(hours=h) - offset for h in local_hours]
+    ends = [s + pd.Timedelta(hours=1) for s in starts]
+    segment = LineString([(lon, 0.0), (lon + 0.001, 0.0)])
+    gdf = gpd.GeoDataFrame(
+        {
+            "segment_start": starts,
+            "segment_end": ends,
+            "geometry": [segment] * 4,
+            "dist_meters": [1000.0] * 4,
+        },
+        crs="EPSG:4326",
+    )
+    assert astronomy.get_nightday_ratio(gdf) == pytest.approx(1.0, rel=1e-6)
 
 
 @pytest.fixture

--- a/tests/test_astronomy.py
+++ b/tests/test_astronomy.py
@@ -56,12 +56,12 @@ def test_is_night(movebank_relocations):
 def test_nightday_ratio(movebank_relocations, timezone):
     # movebank_relocations is subsampled to keep execution speed low.
     # Expected ratios for the full data are:
-    # Habiba=0.45905845612291696, Salif Keita=2.0019632541788472.
+    # Habiba=0.4546939436509577, Salif Keita=2.0114194855402805.
     movebank_relocations.gdf = movebank_relocations.gdf.groupby("groupby_col", group_keys=False).head(100)
 
     trajectory = Trajectory.from_relocations(movebank_relocations)
     expected = pd.Series(
-        [0.3736601604553539, 2.1840195829850435],
+        [0.3855732298373231, 2.529674418228213],
         index=pd.Index(["Habiba", "Salif Keita"], name="groupby_col"),
     )
     # test against a handful of timezone to ensure this calculation is agnotisc of input timezone


### PR DESCRIPTION
## :earth_americas: Summary
Closes #725

## :package: Proposed Changes
https://github.com/wildlife-dynamics/ecoscope/pull/726 didn't go far enough: using UTC date ranges as bins doesn't make sense as we end up pulling in local night of the day, extending the date bin's total night distance and skewing the calculated ratio.

This updates `sun_time` and `get_nightday_ratio` to both offset to local solar time.

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary