### PR TITLE
Fix `persist_geoarrow_for_pydeck`'s treatment of empty dict columns

### DIFF
--- a/ecoscope/platform/tasks/results/_map_utils.py
+++ b/ecoscope/platform/tasks/results/_map_utils.py
@@ -245,17 +245,39 @@ def _pack_color_columns(df):
         df[col] = pd.arrays.ArrowExtensionArray(fsl)
 
 
+def _needs_stringify(series: pd.Series) -> bool:
+    """True if pyarrow can't faithfully represent this column for parquet —
+    either because type inference fails outright (e.g. int/str mixing under a
+    shared key) or because the inferred type contains a struct<> with no fields.
+    """
+
+    def _type_has_empty_struct(t: pa.DataType) -> bool:
+        if pa.types.is_struct(t):
+            if t.num_fields == 0:
+                return True
+            return any(_type_has_empty_struct(t.field(i).type) for i in range(t.num_fields))
+        if pa.types.is_list(t) or pa.types.is_large_list(t) or pa.types.is_fixed_size_list(t):
+            return _type_has_empty_struct(t.value_type)
+        if pa.types.is_map(t):
+            return _type_has_empty_struct(t.item_type)
+        return False
+
+    try:
+        arr = pa.array(series)
+    except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError):
+        return True
+    return _type_has_empty_struct(arr.type)
+
+
 def _stringify_mixed_json(df):
-    """Object columns whose values pyarrow can't infer a unified type for
-    (int/str mixing on the same key, for example) are re-encoded as JSON strings.
+    """Object columns pyarrow can't represent for parquet are
+    re-encoded as JSON strings.
     """
 
     for col in df.columns:
         if df[col].dtype != "object":
             continue
-        try:
-            pa.array(df[col])
-        except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError):
+        if _needs_stringify(df[col]):
             df[col] = df[col].map(lambda v: None if v is None else json.dumps(v, default=str))
 
 

--- a/tests/platform/tasks/test_map_utils.py
+++ b/tests/platform/tasks/test_map_utils.py
@@ -165,6 +165,55 @@ def test_persist_geoarrow_for_pydeck_preserves_uniform_json(tmp_path) -> None:
     assert pa.types.is_struct(schema.field("payload").type)
 
 
+def test_persist_geoarrow_for_pydeck_stringifies_empty_dicts(tmp_path) -> None:
+    # Empty dicts infer as struct<> which pyarrow can construct but parquet
+    # can't write. They should be JSON-encoded like other unrepresentable cols.
+    gdf = gpd.GeoDataFrame(
+        {
+            "meta": [{}, {}, {}],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+    dst = persist_geoarrow_for_pydeck(gdf, str(tmp_path), filename="empty_dicts")
+    schema = pq.read_schema(dst)
+    assert schema.field("meta").type == pa.string()
+    gdf_read = gpd.read_parquet(dst)
+    assert gdf_read["meta"].tolist() == ["{}", "{}", "{}"]
+
+
+def test_persist_geoarrow_for_pydeck_stringifies_none_and_empty_dicts(tmp_path) -> None:
+    gdf = gpd.GeoDataFrame(
+        {
+            "meta": [None, {}, None],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+    dst = persist_geoarrow_for_pydeck(gdf, str(tmp_path), filename="none_empty_dicts")
+    schema = pq.read_schema(dst)
+    assert schema.field("meta").type == pa.string()
+    gdf_read = gpd.read_parquet(dst)
+    assert gdf_read["meta"].tolist() == [None, "{}", None]
+
+
+def test_persist_geoarrow_for_pydeck_stringifies_nested_empty_struct(tmp_path) -> None:
+    # list<struct<>> and struct<x: struct<>> both fail parquet write — the
+    # walker should catch the nested empty struct in either shape.
+    gdf = gpd.GeoDataFrame(
+        {
+            "list_of_empty": [[{}], [{}, {}], []],
+            "nested": [{"inner": {}}, {"inner": {}}, {"inner": {}}],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+    dst = persist_geoarrow_for_pydeck(gdf, str(tmp_path), filename="nested_empty")
+    schema = pq.read_schema(dst)
+    assert schema.field("list_of_empty").type == pa.string()
+    assert schema.field("nested").type == pa.string()
+
+
 def test_persist_geoarrow_for_pydeck_skips_non_color_object_columns(tmp_path) -> None:
     # Ragged tuples must not be coerced to a fixed-size color list.
     gdf = gpd.GeoDataFrame(


### PR DESCRIPTION
## :earth_americas: Summary
Closes #733 

## :package: Proposed Changes
Fixes `persist_geoarrow_for_pydeck` and specifically `_stringify_mixed_json`'s treatment of empty dicts / lists etc

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary