### PR TITLE
Force oneOf format in `get_choices_from_v2_event_type`

### DIFF
--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -631,7 +631,7 @@ class EarthRangerIO(ERClient):
                 if prop_name == choice_field:
                     for definition in prop.get("anyOf", {}):
                         try:
-                            schema = self._get(definition.get("$ref"))
+                            schema = self._get(definition.get("$ref"), params={"s_format": "oneOf"})
                             choices |= {choice.get("const"): choice.get("title") for choice in schema.get("oneOf")}
                         except:
                             continue


### PR DESCRIPTION
## :earth_americas: Summary
Closes #736 

## :package: Proposed Changes
Adds `s_format=oneOf` as a query param when fetching V2 event type choice field display names

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary