### PR TITLE
Add `area_sqkm` to `calculate_linear_time_density` output

### DIFF
--- a/ecoscope/platform/tasks/analysis/__init__.py
+++ b/ecoscope/platform/tasks/analysis/__init__.py
@@ -15,6 +15,7 @@ from ._calculate_feature_density import calculate_feature_density
 from ._create_meshgrid import create_meshgrid
 from ._summary import aggregate_over_rows, summarize_df
 from ._time_density import (
+    TimeDensityReturnGDF,
     TimeDensityReturnGDFSchema,
     calculate_elliptical_time_density,
     calculate_linear_time_density,
@@ -36,6 +37,7 @@ __all__ = [
     "create_meshgrid",
     "aggregate_over_rows",
     "summarize_df",
+    "TimeDensityReturnGDF",
     "TimeDensityReturnGDFSchema",
     "calculate_elliptical_time_density",
     "calculate_linear_time_density",

--- a/ecoscope/platform/tasks/analysis/_time_density.py
+++ b/ecoscope/platform/tasks/analysis/_time_density.py
@@ -252,13 +252,13 @@ def calculate_linear_time_density(
     )
 
     density_grid = calculate_ltd(traj=Trajectory(trajectory_gdf), grid=meshgrid)
-    result = classify_percentile(  # type: ignore[operator]
+    result = classify_percentile(
         df=density_grid,
         percentile_levels=percentiles,  # type: ignore[arg-type]
         input_column_name="density",
     )
 
-    result = result.dissolve(
+    result = result.dissolve(  # type: ignore[operator]
         "percentile",
         aggfunc={"density": "sum"},
         as_index=False,

--- a/ecoscope/platform/tasks/analysis/_time_density.py
+++ b/ecoscope/platform/tasks/analysis/_time_density.py
@@ -162,7 +162,7 @@ def calculate_elliptical_time_density(
     max_speed_factor: MaxSpeedFactorAnnotation = 1.05,
     expansion_factor: ExpansionFactorAnnotation = 1.3,
     percentiles: EtdPercentileAnnotation = None,
-) -> DataFrame[TimeDensityReturnGDFSchema]:
+) -> TimeDensityReturnGDF:
     import geopandas as gpd  # type: ignore[import-untyped]
     import pandas as pd  # type: ignore[import-untyped]
 
@@ -234,7 +234,7 @@ def calculate_linear_time_density(
     trajectory_gdf: TrajectoryAnnotation,
     meshgrid: MeshGridAnnotation,
     percentiles: LtdPercentileAnnotation = None,
-) -> AnyGeoDataFrame:
+) -> TimeDensityReturnGDF:
     from ecoscope import Trajectory
     from ecoscope.analysis.classifier import (
         classify_percentile,

--- a/ecoscope/platform/tasks/analysis/_time_density.py
+++ b/ecoscope/platform/tasks/analysis/_time_density.py
@@ -256,9 +256,10 @@ def calculate_linear_time_density(
     )
 
     result = result.dissolve(
-        "percentiles",
+        "percentile",
         aggfunc={"density": "sum"},
+        as_index=False,
     )
     result["area_sqkm"] = result.area / 1000000.0
 
-    return cast(AnyGeoDataFrame, result)
+    return cast(DataFrame[TimeDensityReturnGDFSchema], result)

--- a/ecoscope/platform/tasks/analysis/_time_density.py
+++ b/ecoscope/platform/tasks/analysis/_time_density.py
@@ -24,6 +24,9 @@ class TimeDensityReturnGDFSchema(JsonSerializableDataFrameModel):
     area_sqkm: pa_typing.Series[float] = pa.Field()
 
 
+TimeDensityReturnGDF: TypeAlias = DataFrame[TimeDensityReturnGDFSchema]
+
+
 class AutoScaleGridCellSize(BaseModel):
     model_config = ConfigDict(json_schema_extra={"title": "Auto-scale"})
     auto_scale_or_custom: Annotated[
@@ -214,7 +217,7 @@ def calculate_elliptical_time_density(
 
     if raster_data is None or raster_data.data is None or raster_data.data.size == 0:
         logger.warning("No raster data was generated.")
-        return cast(DataFrame[TimeDensityReturnGDFSchema], result)
+        return cast(TimeDensityReturnGDF, result)
 
     result = get_percentile_area(
         percentile_levels=percentiles,  # type: ignore[arg-type]
@@ -223,7 +226,7 @@ def calculate_elliptical_time_density(
     result.drop(columns="subject_id", inplace=True)
     result["area_sqkm"] = result.area / 1000000.0
 
-    return cast(DataFrame[TimeDensityReturnGDFSchema], result)
+    return cast(TimeDensityReturnGDF, result)
 
 
 @register()
@@ -262,4 +265,4 @@ def calculate_linear_time_density(
     )
     result["area_sqkm"] = result.area / 1000000.0
 
-    return cast(DataFrame[TimeDensityReturnGDFSchema], result)
+    return cast(TimeDensityReturnGDF, result)

--- a/ecoscope/platform/tasks/analysis/_time_density.py
+++ b/ecoscope/platform/tasks/analysis/_time_density.py
@@ -254,4 +254,11 @@ def calculate_linear_time_density(
         percentile_levels=percentiles,  # type: ignore[arg-type]
         input_column_name="density",
     )
+
+    result = result.dissolve(
+        "percentiles",
+        aggfunc={"density": "sum"},
+    )
+    result["area_sqkm"] = result.area / 1000000.0
+
     return cast(AnyGeoDataFrame, result)

--- a/ecoscope/platform/tasks/analysis/_time_density.py
+++ b/ecoscope/platform/tasks/analysis/_time_density.py
@@ -252,7 +252,7 @@ def calculate_linear_time_density(
     )
 
     density_grid = calculate_ltd(traj=Trajectory(trajectory_gdf), grid=meshgrid)
-    result = classify_percentile(
+    result = classify_percentile(  # type: ignore[operator]
         df=density_grid,
         percentile_levels=percentiles,  # type: ignore[arg-type]
         input_column_name="density",

--- a/ecoscope/platform/tasks/config/_meta_tasks.py
+++ b/ecoscope/platform/tasks/config/_meta_tasks.py
@@ -19,7 +19,7 @@ from ecoscope.platform.tasks.analysis._time_density import (
     MaxSpeedFactorAnnotation,
     MeshGridAnnotation,
     NoDataAnnotation,
-    TimeDensityReturnGDFSchema,
+    TimeDensityReturnGDF,
     TrajectoryAnnotation,
     calculate_elliptical_time_density,
     calculate_linear_time_density,
@@ -115,7 +115,7 @@ def set_ltd_args_with_opacity(
 def call_etd_from_combined_params(
     trajectory_gdf: TrajectoryAnnotation,
     combined_params: EtdArgsWithOpacity,
-) -> DataFrame[TimeDensityReturnGDFSchema]:
+) -> TimeDensityReturnGDF:
     return (
         task(calculate_elliptical_time_density)
         .validate()
@@ -136,7 +136,7 @@ def call_ltd_from_combined_params(
     trajectory_gdf: TrajectoryAnnotation,
     meshgrid: MeshGridAnnotation,
     combined_params: LtdArgsWithOpacity,
-) -> AnyGeoDataFrame:
+) -> TimeDensityReturnGDF:
     return (
         task(calculate_linear_time_density)
         .validate()

--- a/ecoscope/platform/tasks/transformation/_unit.py
+++ b/ecoscope/platform/tasks/transformation/_unit.py
@@ -10,6 +10,8 @@ from wt_registry import register
 class Unit(Enum):
     METER = "m"
     KILOMETER = "km"
+    SQUARE_METER = "m²"
+    SQUARE_KILOMETER = "km²"
     SECOND = "s"
     HOUR = "h"
     DAY = "d"

--- a/tests/platform/tasks/test_calculate_time_density.py
+++ b/tests/platform/tasks/test_calculate_time_density.py
@@ -3,6 +3,7 @@ from importlib.resources import files
 import geopandas as gpd  # type: ignore[import-untyped]
 import numpy as np
 import pytest
+from pydantic import TypeAdapter
 
 from ecoscope.platform.tasks.analysis import (
     calculate_elliptical_time_density,
@@ -14,6 +15,7 @@ from ecoscope.platform.tasks.analysis._create_meshgrid import (
 from ecoscope.platform.tasks.analysis._time_density import (
     AutoScaleGridCellSize,
     CustomGridCellSize,
+    TimeDensityReturnGDF,
 )
 
 
@@ -45,6 +47,8 @@ def test_calculate_elliptical_time_density_custom_cell_size():
             106.6875,
         ]
     )
+    ta = TypeAdapter(TimeDensityReturnGDF)
+    ta.validate_python(result)
 
 
 @pytest.mark.parametrize(
@@ -85,6 +89,8 @@ def test_calculate_elliptical_time_density_custom_auto_scale(percentiles):
     assert list(result["area_sqkm"]) == pytest.approx(
         [626.837667, 499.715083, 354.804824, 263.25759, 195.664425, 143.487245]
     )
+    ta = TypeAdapter(TimeDensityReturnGDF)
+    ta.validate_python(result)
 
 
 @pytest.mark.parametrize(
@@ -118,6 +124,8 @@ def test_calculate_linear_time_density_custom_auto_scale(percentiles):
     assert set(percentile_without_nans.unique()) == set(percentile_levels)
     # Density values should be normalized
     assert round(result.density.sum(), 1) == 1.0
+    ta = TypeAdapter(TimeDensityReturnGDF)
+    ta.validate_python(result)
 
 
 def test_calculate_elliptical_time_density_custom_auto_scale_raises_empty_percentiles():

--- a/tests/platform/tasks/test_unit.py
+++ b/tests/platform/tasks/test_unit.py
@@ -16,6 +16,12 @@ def test_apply_speed_conversion():
     assert data.unit == Unit.KILOMETERS_PER_HOUR
 
 
+def test_apply_area_conversion():
+    data = with_unit(1_000_000, Unit.SQUARE_METER, Unit.SQUARE_KILOMETER)
+    assert data.value == pytest.approx(1.0)
+    assert data.unit == Unit.SQUARE_KILOMETER
+
+
 def test_apply_unit_no_unit():
     data = with_unit(1)
     assert data.value == 1

--- a/tests/platform/tasks/test_value_mapping.py
+++ b/tests/platform/tasks/test_value_mapping.py
@@ -143,6 +143,19 @@ def test_map_values_with_unit_speed_conversion():
     assert result["speed_kmh"].tolist() == ["36.0 km/h", "0.0 km/h"]
 
 
+def test_map_values_with_unit_area_conversion():
+    df = pd.DataFrame({"area": [1_000_000.0, 500_000.0, 0.0]})
+    result = map_values_with_unit(
+        df,
+        input_column_name="area",
+        output_column_name="area_km2",
+        original_unit=Unit.SQUARE_METER,
+        new_unit=Unit.SQUARE_KILOMETER,
+        decimal_places=2,
+    )
+    assert result["area_km2"].tolist() == ["1.00 km²", "0.50 km²", "0.00 km²"]
+
+
 def test_fill_na_string():
     column_with_nans = pd.Series([np.nan, "Value", np.nan, "More Value"])
     column_with_nans_filled = pd.Series(["None", "Value", "None", "More Value"])


### PR DESCRIPTION
## :earth_americas: Summary
Closes #657

## :package: Proposed Changes
- Adds `area_sqkm` to `calculate_linear_time_density` output
- Better pandera validation of both ETD and LTD tasks and test coverage for both
- Adds `m²` and `km²` to the enum used by `map_values_with_unit` (towards https://github.com/wildlife-dynamics/ecoscope-workflows/issues/1332) 

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary