### PR TITLE
Set iers config max age to None and warn when accuracy is degraded

### DIFF
--- a/ecoscope/platform/tasks/analysis/_aggregation.py
+++ b/ecoscope/platform/tasks/analysis/_aggregation.py
@@ -133,4 +133,6 @@ def get_night_day_ratio(
 
     # See classify_is_night for rationale on disabling auto-download.
     with iers.conf.set_temp("auto_download", False):
-        return astronomy.get_nightday_ratio(df)
+        with iers.conf.set_temp("auto_max_age", None):
+            with iers.conf.set_temp("iers_degraded_accuracy", "warn"):
+                return astronomy.get_nightday_ratio(df)

--- a/ecoscope/platform/tasks/transformation/_classification.py
+++ b/ecoscope/platform/tasks/transformation/_classification.py
@@ -212,7 +212,9 @@ def classify_is_night(
     # Bundled IERS data is accurate to ~few-ms, well below
     # the minute-scale precision needed here.
     with iers.conf.set_temp("auto_download", False):
-        relocations["is_night"] = is_night(relocations.geometry, relocations.fixtime)
+        with iers.conf.set_temp("auto_max_age", None):
+            with iers.conf.set_temp("iers_degraded_accuracy", "warn"):
+                relocations["is_night"] = is_night(relocations.geometry, relocations.fixtime)
 
     return relocations
 


### PR DESCRIPTION
## :earth_americas: Summary
Closes #764 

## :package: Proposed Changes
In tasks where we set iers `auto_download` to `False`, also set:
`auto_max_age` to `None`, and `iers_degraded_accuracy` to "warn"

## 📋 Checklist
- [x] Corresponding ecoscope.platform tasks updated if necessary