### PR TITLE
Cleanup io tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       os:
         type: string
         required: true
-      python-version:    
+      python-version:
         type: string
         default: "3.12"
 
@@ -21,6 +21,9 @@ jobs:
         to_test: ["not platform", "ecoscope.platform"]
     name: ${{ inputs.os }}, ${{ inputs.io }}${{ matrix.to_test == 'ecoscope.platform' && ', ecoscope.platform' || '' }}
     runs-on: ${{ inputs.os }}
+    # Backstop against hung network calls (e.g. an unresponsive ER/SMART server).
+    # Normal runs finish well within this; a hang fails in minutes, not hours.
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/ecoscope/analysis/UD/etd_range.py
+++ b/ecoscope/analysis/UD/etd_range.py
@@ -36,7 +36,7 @@ def __etd__(_, a):
     return np.exp(-((s / el) ** k)) * s ** (k - 2) / np.sqrt(s**2 - m**2)
 
 
-_etd = scipy.LowLevelCallable(__etd__.ctypes)
+_etd = scipy.LowLevelCallable(__etd__.ctypes)  # type: ignore[call-overload]
 
 
 class WeibullPDF:

--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -69,7 +69,7 @@ class EarthRangerIO(ERClient):
                 raise ERClientException("Authorization token is invalid or expired.")
 
     def _token_request(self, payload):
-        response = requests.post(self.token_url, data=payload)
+        response = requests.post(self.token_url, data=payload, timeout=30)
         if response.ok:
             self.auth = response.json()
             expires_in = int(self.auth["expires_in"]) - 5 * 60

--- a/ecoscope/io/earthranger_utils.py
+++ b/ecoscope/io/earthranger_utils.py
@@ -1,6 +1,6 @@
 import geopandas as gpd  # type: ignore[import-untyped]
 import pandas as pd
-import pyarrow as pa
+import pyarrow as pa  # type: ignore[import-untyped]
 import shapely.geometry
 import shapely.wkb
 from shapely.geometry import shape

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,9 @@ def er_io():
     er_io = ecoscope.io.EarthRangerIO(server=ER_SERVER, username=ER_USERNAME, password=ER_PASSWORD)
 
     er_io.GROUP_NAME = "Elephants"
-    er_io.SUBJECT_IDS = er_io.get_subjects(subject_group_name=er_io.GROUP_NAME).id.tolist()
-    er_io.SUBJECTSOURCE_IDS, er_io.SOURCE_IDS = er_io.get_subjectsources(subjects=",".join(er_io.SUBJECT_IDS))[
-        ["id", "source"]
-    ].values.T.tolist()
-
+    er_io.SUBJECT_IDS = ["64444ed7-72ec-4531-a2b1-fb25c7197b2d", "b8be28f7-8c20-46d9-85a5-fd817351bde5"]
+    er_io.SUBJECTSOURCE_IDS = ["893d4255-51e1-4567-8ac1-028e7c532431", "59568b94-b1c8-4f19-89a7-3d08ae60e52b"]
+    er_io.SOURCE_IDS = ["64444ed7-72ec-4531-a2b1-fb25c7197b2d", "b8be28f7-8c20-46d9-85a5-fd817351bde5"]
     return er_io
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def er_io():
     er_io.GROUP_NAME = "Elephants"
     er_io.SUBJECT_IDS = ["64444ed7-72ec-4531-a2b1-fb25c7197b2d", "b8be28f7-8c20-46d9-85a5-fd817351bde5"]
     er_io.SUBJECTSOURCE_IDS = ["893d4255-51e1-4567-8ac1-028e7c532431", "59568b94-b1c8-4f19-89a7-3d08ae60e52b"]
-    er_io.SOURCE_IDS = ["64444ed7-72ec-4531-a2b1-fb25c7197b2d", "b8be28f7-8c20-46d9-85a5-fd817351bde5"]
+    er_io.SOURCE_IDS = ["84f240db-dd7b-4297-bf85-8c051b8055c7", "7e5b3e3b-3d1c-481c-905e-2eb9454c6a31"]
     return er_io
 
 

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -104,11 +104,11 @@ def test_get_subjectsource_no_observations(er_io):
 def test_get_subjectgroup_observations(er_io):
     relocations = er_io.get_subjectgroup_observations(
         subject_group_name=er_io.GROUP_NAME,
-        since="2008-03-01",
-        until="2008-04-01",
+        since="2008-12-01",
+        until="2008-12-31",
     )
     assert "groupby_col" in relocations.gdf
-    assert len(relocations.gdf["extra__subject_id"].unique()) == 2
+    assert relocations.gdf["extra__subject_id"].unique() == ["b8be28f7-8c20-46d9-85a5-fd817351bde5"]
 
 
 def test_get_events(er_events_io):

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -61,6 +61,8 @@ def test_get_source_observations(er_io):
     relocations = er_io.get_source_observations(
         source_ids=er_io.SOURCE_IDS,
         include_source_details=True,
+        since="2008-03-01",
+        until="2008-04-01",
     )
     assert isinstance(relocations, ecoscope.Relocations)
     assert "fixtime" in relocations.gdf
@@ -80,6 +82,8 @@ def test_get_subjectsource_observations(er_io):
     relocations = er_io.get_subjectsource_observations(
         subjectsource_ids=er_io.SUBJECTSOURCE_IDS,
         include_source_details=True,
+        since="2008-03-01",
+        until="2008-04-01",
     )
     assert isinstance(relocations, ecoscope.Relocations)
     assert "fixtime" in relocations.gdf
@@ -91,18 +95,28 @@ def test_get_subjectsource_no_observations(er_io):
     relocations = er_io.get_subjectsource_observations(
         subjectsource_ids=str(uuid.uuid4()),
         include_source_details=True,
+        since="2008-03-01",
+        until="2008-04-01",
     )
     assert relocations.gdf.empty
 
 
 def test_get_subjectgroup_observations(er_io):
-    relocations = er_io.get_subjectgroup_observations(subject_group_name=er_io.GROUP_NAME)
+    relocations = er_io.get_subjectgroup_observations(
+        subject_group_name=er_io.GROUP_NAME,
+        since="2008-03-01",
+        until="2008-04-01",
+    )
     assert "groupby_col" in relocations.gdf
     assert len(relocations.gdf["extra__subject_id"].unique()) == 2
 
 
 def test_get_events(er_events_io):
-    events = er_events_io.get_events(event_type=["e00ce1f6-f9f1-48af-93c9-fb89ec493b8a"])
+    events = er_events_io.get_events(
+        event_type=["e00ce1f6-f9f1-48af-93c9-fb89ec493b8a"],
+        since="2023-11-15",
+        until="2023-11-16",
+    )
     assert not events.empty
     check_time_is_parsed(events)
 


### PR DESCRIPTION
## :earth_americas: Summary
Closes #777 

## :package: Proposed Changes
- Reduces the scope of some previously unbounded IO tests
- Fixes IO test fixtures against some known keys instead of querying ER in coftest
- Adds a 30s timeout to ER IO's token request 
- Adds a GH action level timeout to all tests - this is a safeguard against hanging requests since the underlying `ERClient`'s requests can hang indefinitely

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary