### PR TITLE
Bump ecoscope-io-core in release recipe

### DIFF
--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -79,7 +79,7 @@ outputs:
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
         - pydeck ==0.9.2
-        - ecoscope-earthranger-io-core ==0.0.16
+        - ecoscope-earthranger-io-core ==0.0.20
     tests:
       - python:
           imports:


### PR DESCRIPTION
## :earth_americas: Summary
Closes #775

## :package: Proposed Changes
Bumps ecoscope-io-core in release recipe from `0.0.16` to `0.0.20`

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary