### PR TITLE
Update `ecoscope-earthranger-io-core` version pins

### DIFF
--- a/publish/recipes/release/ecoscope.yaml
+++ b/publish/recipes/release/ecoscope.yaml
@@ -79,7 +79,7 @@ outputs:
         - wt-registry >=0.2.0,<0.3.0
         - wt-task >=0.1.0,<0.2.0
         - pydeck ==0.9.2
-        - ecoscope-earthranger-io-core ==0.0.20
+        - ecoscope-earthranger-io-core <0.1.0
     tests:
       - python:
           imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.20",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.21",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",


### PR DESCRIPTION
## :earth_americas: Summary
Closes #775 

## :package: Proposed Changes
Bumps `ecoscope-earthranger-io-core` to `0.0.21` in pyproject toml, and relaxes to a range `<0.1.0` in the conda recipe

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary