### PR TITLE
fix: migrate Convert Units conditional from legacy dependencies to allOf/if/then

### DIFF
--- a/ecoscope/platform/tasks/analysis/_summary.py
+++ b/ecoscope/platform/tasks/analysis/_summary.py
@@ -28,40 +28,41 @@ class _BaseSummaryParam(BaseModel):
 
 
 # The unit fields are excluded from the model's own JSON schema (SkipJsonSchema)
-# and re-introduced via the `dependencies` block in json_schema_extra, so the form
-# only shows them once "Convert Units" is checked. Note the docstring renders as
-# the form's helper text.
+# and re-introduced via the allOf/if/then block in json_schema_extra, so the form
+# only shows them once "Convert Units" is checked. if/then (not the legacy
+# `dependencies` keyword) is understood by BOTH the RJSF renderer and JSON Schema
+# 2020-12 validators (ecoscope-server validates submitted formdata with
+# Draft202012Validator, which silently ignores `dependencies`). See
+# wildlife-dynamics/wt-download-subject-tracks#31 for the full dialect story.
+# Note the docstring renders as the form's helper text.
 class StatSummaryParam(_BaseSummaryParam):
     """Pick a column and statistic, with optional unit conversion."""
 
     model_config = ConfigDict(
         title="Statistic",
         json_schema_extra={
-            "dependencies": {
-                "convert_units": {
-                    "oneOf": [
-                        {"properties": {"convert_units": {"const": False}}},
-                        {
-                            "properties": {
-                                "convert_units": {"const": True},
-                                # No `default` on these: a default on a dependency branch
-                                # gets seeded into formData even while unchecked, leaving
-                                # an orphaned value behind.
-                                "original_unit": {
-                                    "title": "Original Unit",
-                                    "type": "string",
-                                    "oneOf": UNIT_OPTIONS,
-                                },
-                                "new_unit": {
-                                    "title": "New Unit",
-                                    "type": "string",
-                                    "oneOf": UNIT_OPTIONS,
-                                },
-                            }
-                        },
-                    ]
+            "allOf": [
+                {
+                    "if": {"properties": {"convert_units": {"const": True}}},
+                    "then": {
+                        "properties": {
+                            # No `default` on these: a default on a conditional branch
+                            # gets seeded into formData even while unchecked, leaving
+                            # an orphaned value behind.
+                            "original_unit": {
+                                "title": "Original Unit",
+                                "type": "string",
+                                "oneOf": UNIT_OPTIONS,
+                            },
+                            "new_unit": {
+                                "title": "New Unit",
+                                "type": "string",
+                                "oneOf": UNIT_OPTIONS,
+                            },
+                        }
+                    },
                 }
-            }
+            ]
         },
     )
     aggregator: Annotated[AggOperations, Field(title="Statistic")]

--- a/tests/platform/tasks/test_patrol_summary.py
+++ b/tests/platform/tasks/test_patrol_summary.py
@@ -120,14 +120,15 @@ def test_custom_metric_requires_both_units_when_checked():
         )
 
 
-def test_custom_metric_schema_hides_units_behind_dependency():
+def test_custom_metric_schema_hides_units_behind_conditional():
     schema = CustomMetric.model_json_schema()
     assert "original_unit" not in schema["properties"]
     assert "new_unit" not in schema["properties"]
-    branches = schema["dependencies"]["convert_units"]["oneOf"]
-    checked = branches[1]["properties"]
-    assert checked["convert_units"]["const"] is True
-    assert {o["const"] for o in checked["original_unit"]["oneOf"]} == {u.value for u in Unit}
+    conditional = schema["allOf"][0]
+    assert conditional["if"]["properties"]["convert_units"]["const"] is True
+    revealed = conditional["then"]["properties"]
+    assert {o["const"] for o in revealed["original_unit"]["oneOf"]} == {u.value for u in Unit}
+    assert {o["const"] for o in revealed["new_unit"]["oneOf"]} == {u.value for u in Unit}
 
 
 def test_total_distance_metric_labeled_units_and_decimals():


### PR DESCRIPTION
## Summary
- Rewrite `StatSummaryParam`'s `json_schema_extra` conditional (Convert Units → Original/New Unit reveal) from the legacy `dependencies`/`oneOf` keyword to `allOf`/`if`/`then`
- Rename + update the schema-shape test accordingly (also asserts `new_unit` options now)

## Why
`dependencies` was removed from the JSON Schema vocabulary in 2019-09. ecoscope-server validates submitted formdata against the compiled rjsf with `Draft202012Validator`, which silently ignores the keyword — so the units conditional was unenforced server-side. `allOf`/`if`/`then` is understood by **both** the RJSF renderer and the 2020-12 validator. Same dialect fix as wildlife-dynamics/wt-download-subject-tracks#31, which has the full analysis; unlike that case there's no `additionalProperties: false` on this model, so nothing was being rejected — this closes the enforcement gap and retires the dead keyword.

## Verification
- `tests/platform/tasks/test_patrol_summary.py` — 11 passed
- Renderer parity against ecoscope-web's installed `@rjsf` packages (`retrieveSchema` + the app's exact ajv config): unit fields hidden when unchecked, both labeled unit selects revealed when checked, zero ajv errors for valid and orphaned-unit form states
- `Draft202012Validator`: now enforces the Unit enum when Convert Units is checked (previously ignored), tolerates orphaned unit values left by unchecking (matching the runtime `check_units` validator, which nulls them)

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)