### PR TITLE
feat: add "Normalised (LTD)" patrol density weighting with mode-aware classification

### DIFF
--- a/ecoscope/analysis/feature_density.py
+++ b/ecoscope/analysis/feature_density.py
@@ -32,11 +32,9 @@ def calculate_feature_density(
             result = selection.clip_by_rect(*cell.bounds)
 
             if sum_column:
-                # apportion each feature's value across cells by the fraction
-                # of its length falling inside the cell (assumes the value
-                # accrues uniformly along the line, e.g. constant speed).
-                # NOTE: zero-length segments (start == end) contribute nothing
-                # (0/0 -> NaN -> 0), so e.g. time spent stationary is dropped.
+                # assumes the value accrues uniformly along the line; zero-length
+                # segments contribute nothing (0/0 -> NaN -> 0), so e.g. time
+                # spent stationary is dropped.
                 fraction = (result.length / line_lengths).fillna(0)
                 return (selection[sum_column] * fraction).sum()
 

--- a/ecoscope/platform/tasks/analysis/__init__.py
+++ b/ecoscope/platform/tasks/analysis/__init__.py
@@ -14,7 +14,6 @@ from ._aggregation import (
 from ._calculate_feature_density import calculate_feature_density
 from ._create_meshgrid import create_meshgrid
 from ._density_weighting import (
-    calculate_classified_track_density,
     get_density_colormap,
     get_density_legend_title,
     get_weighting_column,
@@ -29,6 +28,7 @@ from ._time_density import (
     calculate_elliptical_time_density,
     calculate_linear_time_density,
 )
+from ._track_density import calculate_classified_track_density
 
 __all__ = [
     "apply_arithmetic_operation",

--- a/ecoscope/platform/tasks/analysis/__init__.py
+++ b/ecoscope/platform/tasks/analysis/__init__.py
@@ -15,6 +15,7 @@ from ._calculate_feature_density import calculate_feature_density
 from ._create_meshgrid import create_meshgrid
 from ._density_weighting import (
     calculate_classified_track_density,
+    get_density_colormap,
     get_density_legend_title,
     get_weighting_column,
     normalize_density_units,
@@ -44,6 +45,7 @@ __all__ = [
     "calculate_classified_track_density",
     "calculate_feature_density",
     "create_meshgrid",
+    "get_density_colormap",
     "get_density_legend_title",
     "get_weighting_column",
     "normalize_density_units",

--- a/ecoscope/platform/tasks/analysis/__init__.py
+++ b/ecoscope/platform/tasks/analysis/__init__.py
@@ -14,6 +14,7 @@ from ._aggregation import (
 from ._calculate_feature_density import calculate_feature_density
 from ._create_meshgrid import create_meshgrid
 from ._density_weighting import (
+    calculate_classified_track_density,
     get_density_legend_title,
     get_weighting_column,
     normalize_density_units,
@@ -40,6 +41,7 @@ __all__ = [
     "dataframe_column_sum",
     "dataframe_count",
     "get_night_day_ratio",
+    "calculate_classified_track_density",
     "calculate_feature_density",
     "create_meshgrid",
     "get_density_legend_title",

--- a/ecoscope/platform/tasks/analysis/_calculate_feature_density.py
+++ b/ecoscope/platform/tasks/analysis/_calculate_feature_density.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Literal
 
+import pandas as pd
 from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
@@ -36,13 +37,7 @@ def calculate_feature_density(
 ) -> AnyGeoDataFrame:
     """
     Count features or sum column values per grid cell.
-
-    Sum mode is optional: when `sum_column` is None or an empty string, rows are
-    counted. Sum-column values are coerced to numeric (non-castable values become
-    NaN and are ignored by the per-cell sum).
     """
-    import pandas as pd
-
     from ecoscope.analysis.feature_density import (
         calculate_feature_density,
     )

--- a/ecoscope/platform/tasks/analysis/_calculate_feature_density.py
+++ b/ecoscope/platform/tasks/analysis/_calculate_feature_density.py
@@ -26,15 +26,37 @@ def calculate_feature_density(
     ],
     sum_column: Annotated[
         str | SkipJsonSchema[None],
-        Field(description="Sum values in this column per grid cell, rather than counting rows"),
+        Field(
+            description=(
+                "Sum values in this column per grid cell, rather than counting rows."
+                " Leave empty to count rows per cell."
+            )
+        ),
     ] = None,
 ) -> AnyGeoDataFrame:
     """
     Count features or sum column values per grid cell.
+
+    Sum mode is optional: when `sum_column` is None or an empty string, rows are
+    counted. Sum-column values are coerced to numeric (non-castable values become
+    NaN and are ignored by the per-cell sum).
     """
+    import pandas as pd
+
     from ecoscope.analysis.feature_density import (
         calculate_feature_density,
     )
+
+    if not sum_column:
+        sum_column = None
+    elif sum_column not in geodataframe.columns:
+        raise ValueError(
+            f"Column '{sum_column}' not found in the feature data."
+            f" Available columns: {', '.join(str(c) for c in geodataframe.columns)}"
+        )
+    else:
+        geodataframe = geodataframe.copy()
+        geodataframe[sum_column] = pd.to_numeric(geodataframe[sum_column], errors="coerce")
 
     result = calculate_feature_density(
         selection=geodataframe,

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -29,9 +29,7 @@ class UDWeightingSpec:
     legend_label: str | None = None  # legend title prefix when it differs from option_label
     percentiles: tuple[float, ...] | None = None  # percentile bins; None -> LTD defaults
     display_unit: Unit = Unit.PERCENT  # unit shown on the map and in the legend title
-    # Percentiles are emitted ascending and the lowest isopleth is the densest
-    # core, so it gets the first color: red -> green (matches patrols' Time
-    # Density Map).
+    # Lowest isopleth is the densest core, so red comes first (patrols parity).
     colormap: str = "RdYlGn"
     mode: Literal["ud"] = "ud"  # union discriminator
 

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -1,11 +1,11 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 from pydantic import Field
 from wt_registry import register
 
-from ecoscope.platform.annotations import AnyGeoDataFrame
+from ecoscope.platform.annotations import AnyDataFrame, AnyGeoDataFrame
 from ecoscope.platform.tasks.transformation._unit import Unit, with_unit
 
 
@@ -102,9 +102,11 @@ def _classified_sum_density(
         apply_classification,
     )
 
+    # copy: calculate_feature_density writes into the grid it is given, and the
+    # same meshgrid object is shared across mapvalues groups
     result = calculate_feature_density(
         geodataframe=geodataframe,
-        meshgrid=meshgrid,
+        meshgrid=meshgrid.copy(),
         geometry_type="line",
         sum_column=weighting_spec.density_sum_column,
     )
@@ -114,12 +116,15 @@ def _classified_sum_density(
     if result.empty:
         return _empty_density_result(meshgrid)
 
-    return apply_classification(
-        df=result,
-        input_column_name="density",
-        output_column_name="density_bins",
-        label_options=DefaultLabels(label_ranges=True, label_decimals=1),
-        classification_options=SharedArgs(scheme="equal_interval", k=10),
+    return cast(
+        AnyGeoDataFrame,
+        apply_classification(
+            df=cast(AnyDataFrame, result),
+            input_column_name="density",
+            output_column_name="density_bins",
+            label_options=DefaultLabels(label_ranges=True, label_decimals=1),
+            classification_options=SharedArgs(scheme="equal_interval", k=10),
+        ),
     )
 
 
@@ -138,10 +143,10 @@ def _classified_ltd_density(
 
     result = classify_percentile(
         df=density_grid,
-        percentile_levels=[float(p) for p in LTD_DEFAULT_PERCENTILES],
+        percentile_levels=[float(p) for p in LTD_DEFAULT_PERCENTILES],  # type: ignore[arg-type,misc]
         input_column_name="density",
     )
-    result = result.dissolve(
+    result = result.dissolve(  # type: ignore[operator]
         "percentile",
         aggfunc={"density": "sum"},
         as_index=False,

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -11,7 +11,9 @@ from ecoscope import Trajectory
 from ecoscope.analysis.classifier import classify_percentile
 from ecoscope.analysis.linear_time_density import calculate_ltd
 from ecoscope.platform.annotations import AnyDataFrame, AnyGeoDataFrame
-from ecoscope.platform.tasks.analysis._calculate_feature_density import calculate_feature_density
+from ecoscope.platform.tasks.analysis._calculate_feature_density import (
+    calculate_feature_density,
+)
 from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES
 from ecoscope.platform.tasks.transformation._classification import (
     DefaultLabels,
@@ -29,6 +31,8 @@ class SumWeightingSpec:
     display_unit: Unit  # unit shown on the map and in the legend title
     option_label: str  # form dropdown label and default legend title prefix
     legend_label: str | None = None  # legend title prefix when it differs from option_label
+    # Bins are emitted ascending, so low sums get the first colors: green -> red.
+    colormap: str = "RdYlGn_r"
     mode: Literal["sum"] = "sum"  # union discriminator
 
 
@@ -39,6 +43,10 @@ class UDWeightingSpec:
     legend_label: str | None = None  # legend title prefix when it differs from option_label
     percentiles: tuple[float, ...] | None = None  # percentile bins; None -> LTD defaults
     display_unit: Unit = Unit.PERCENT  # unit shown on the map and in the legend title
+    # Percentiles are emitted ascending and the lowest isopleth is the densest
+    # core, so it gets the first color: red -> green (matches patrols' Time
+    # Density Map).
+    colormap: str = "RdYlGn"
     mode: Literal["ud"] = "ud"  # union discriminator
 
 
@@ -59,11 +67,17 @@ def labeled_weighting(specs: dict[str, WeightingSpec]) -> Callable[[dict], None]
 def normalize_density_units(
     df: Annotated[
         AnyGeoDataFrame,
-        Field(description="Feature density output with a raw 'density' column.", exclude=True),
+        Field(
+            description="Feature density output with a raw 'density' column.",
+            exclude=True,
+        ),
     ],
     weighting_spec: Annotated[
         SumWeightingSpec,
-        Field(description="The weighting the density was summed from; determines the display unit.", exclude=True),
+        Field(
+            description="The weighting the density was summed from; determines the display unit.",
+            exclude=True,
+        ),
     ],
 ) -> AnyGeoDataFrame:
     """
@@ -91,6 +105,23 @@ def get_density_legend_title(
 
 
 @register()
+def get_density_colormap(
+    weighting_spec: Annotated[
+        WeightingSpec,
+        Field(
+            description="The weighting the density was summed from; determines the colormap direction.",
+            exclude=True,
+        ),
+    ],
+) -> str:
+    """
+    Colormap for the density map: high sums are red, but for percentile (UD)
+    weightings the lowest isopleth is the densest core, so the direction flips.
+    """
+    return weighting_spec.colormap
+
+
+@register()
 def get_weighting_column(
     weighting_spec: Annotated[
         SumWeightingSpec,
@@ -105,7 +136,10 @@ def get_weighting_column(
 
 def _empty_density_result(meshgrid: AnyGeoDataFrame) -> AnyGeoDataFrame:
     return gpd.GeoDataFrame(
-        {"density": pd.Series(dtype="float64"), "density_bins": pd.Series(dtype="object")},
+        {
+            "density": pd.Series(dtype="float64"),
+            "density_bins": pd.Series(dtype="object"),
+        },
         geometry=gpd.GeoSeries(dtype="geometry"),
         crs=meshgrid.crs,
     )
@@ -173,7 +207,10 @@ def _classified_ud_density(
 def calculate_classified_track_density(
     geodataframe: Annotated[
         AnyGeoDataFrame,
-        Field(description="The trajectory segments to grid into a density surface.", exclude=True),
+        Field(
+            description="The trajectory segments to grid into a density surface.",
+            exclude=True,
+        ),
     ],
     meshgrid: Annotated[
         AnyGeoDataFrame,
@@ -181,7 +218,10 @@ def calculate_classified_track_density(
     ],
     weighting_spec: Annotated[
         WeightingSpec,
-        Field(description="The weighting that selects the density calculation mode.", exclude=True),
+        Field(
+            description="The weighting that selects the density calculation mode.",
+            exclude=True,
+        ),
     ],
 ) -> AnyGeoDataFrame:
     """

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal, TypeAlias, cast
 
 import geopandas as gpd  # type: ignore[import-untyped]
 import pandas as pd
@@ -22,16 +22,27 @@ from ecoscope.platform.tasks.transformation._unit import Unit, with_unit
 
 
 @dataclass(frozen=True)
-class WeightingSpec:
+class SumWeightingSpec:
+    # Per-cell column sum, equal-interval value bins.
     density_sum_column: str  # gdf column the density is summed from
     original_unit: Unit  # unit of the raw summed column
     display_unit: Unit  # unit shown on the map and in the legend title
     option_label: str  # form dropdown label and default legend title prefix
-    # "sum": per-cell column sum, equal-interval value bins;
-    # "ltd": linear time density, percentile bins.
-    mode: Literal["sum", "ltd"] = "sum"
     legend_label: str | None = None  # legend title prefix when it differs from option_label
-    percentiles: tuple[float, ...] | None = None  # "ltd" percentile bins; None -> LTD defaults
+    mode: Literal["sum"] = "sum"  # union discriminator
+
+
+@dataclass(frozen=True)
+class UDWeightingSpec:
+    # Utilisation distribution (currently LTD), percentile bins.
+    option_label: str  # form dropdown label and default legend title prefix
+    legend_label: str | None = None  # legend title prefix when it differs from option_label
+    percentiles: tuple[float, ...] | None = None  # percentile bins; None -> LTD defaults
+    display_unit: Unit = Unit.PERCENT  # unit shown on the map and in the legend title
+    mode: Literal["ud"] = "ud"  # union discriminator
+
+
+WeightingSpec: TypeAlias = SumWeightingSpec | UDWeightingSpec
 
 
 def labeled_weighting(specs: dict[str, WeightingSpec]) -> Callable[[dict], None]:
@@ -51,7 +62,7 @@ def normalize_density_units(
         Field(description="Feature density output with a raw 'density' column.", exclude=True),
     ],
     weighting_spec: Annotated[
-        WeightingSpec,
+        SumWeightingSpec,
         Field(description="The weighting the density was summed from; determines the display unit.", exclude=True),
     ],
 ) -> AnyGeoDataFrame:
@@ -82,7 +93,7 @@ def get_density_legend_title(
 @register()
 def get_weighting_column(
     weighting_spec: Annotated[
-        WeightingSpec,
+        SumWeightingSpec,
         Field(description="The weighting to read the column name from.", exclude=True),
     ],
 ) -> str:
@@ -103,7 +114,7 @@ def _empty_density_result(meshgrid: AnyGeoDataFrame) -> AnyGeoDataFrame:
 def _classified_sum_density(
     geodataframe: AnyGeoDataFrame,
     meshgrid: AnyGeoDataFrame,
-    weighting_spec: WeightingSpec,
+    weighting_spec: SumWeightingSpec,
 ) -> AnyGeoDataFrame:
     result = calculate_feature_density(
         geodataframe=geodataframe,
@@ -129,10 +140,10 @@ def _classified_sum_density(
     )
 
 
-def _classified_ltd_density(
+def _classified_ud_density(
     geodataframe: AnyGeoDataFrame,
     meshgrid: AnyGeoDataFrame,
-    weighting_spec: WeightingSpec,
+    weighting_spec: UDWeightingSpec,
 ) -> AnyGeoDataFrame:
     density_grid = calculate_ltd(traj=Trajectory(geodataframe), grid=meshgrid.copy())
     if density_grid["density"].isna().all():
@@ -177,13 +188,13 @@ def calculate_classified_track_density(
     Calculate a classified track density grid in the mode selected by the weighting.
 
     Emits a uniform shape across modes: a 'density' column with the numeric
-    display value (display-unit sums for "sum" weightings, percentiles for
-    "ltd") and a 'density_bins' column with ready-to-render string bin labels,
+    display value (display-unit sums for sum weightings, percentiles for UD)
+    and a 'density_bins' column with ready-to-render string bin labels,
     sorted ascending with NaN cells dropped.
     """
     if geodataframe.empty:
         return _empty_density_result(meshgrid)
 
-    if weighting_spec.mode == "ltd":
-        return _classified_ltd_density(geodataframe, meshgrid, weighting_spec)
+    if isinstance(weighting_spec, UDWeightingSpec):
+        return _classified_ud_density(geodataframe, meshgrid, weighting_spec)
     return _classified_sum_density(geodataframe, meshgrid, weighting_spec)

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, TypeAlias
 
 from pydantic import Field
 from wt_registry import register
@@ -19,7 +19,6 @@ class SumWeightingSpec:
     legend_label: str | None = None  # legend title prefix when it differs from option_label
     # Bins are emitted ascending, so low sums get the first colors: green -> red.
     colormap: str = "RdYlGn_r"
-    mode: Literal["sum"] = "sum"  # union discriminator
 
 
 @dataclass(frozen=True)
@@ -31,7 +30,6 @@ class UDWeightingSpec:
     display_unit: Unit = Unit.PERCENT  # unit shown on the map and in the legend title
     # Lowest isopleth is the densest core, so red comes first (patrols parity).
     colormap: str = "RdYlGn"
-    mode: Literal["ud"] = "ud"  # union discriminator
 
 
 WeightingSpec: TypeAlias = SumWeightingSpec | UDWeightingSpec

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -2,10 +2,22 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Literal, cast
 
+import geopandas as gpd  # type: ignore[import-untyped]
+import pandas as pd
 from pydantic import Field
 from wt_registry import register
 
+from ecoscope import Trajectory
+from ecoscope.analysis.classifier import classify_percentile
+from ecoscope.analysis.linear_time_density import calculate_ltd
 from ecoscope.platform.annotations import AnyDataFrame, AnyGeoDataFrame
+from ecoscope.platform.tasks.analysis._calculate_feature_density import calculate_feature_density
+from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES
+from ecoscope.platform.tasks.transformation._classification import (
+    DefaultLabels,
+    SharedArgs,
+    apply_classification,
+)
 from ecoscope.platform.tasks.transformation._unit import Unit, with_unit
 
 
@@ -81,9 +93,6 @@ def get_weighting_column(
 
 
 def _empty_density_result(meshgrid: AnyGeoDataFrame) -> AnyGeoDataFrame:
-    import geopandas as gpd  # type: ignore[import-untyped]
-    import pandas as pd
-
     return gpd.GeoDataFrame(
         {"density": pd.Series(dtype="float64"), "density_bins": pd.Series(dtype="object")},
         geometry=gpd.GeoSeries(dtype="geometry"),
@@ -96,15 +105,6 @@ def _classified_sum_density(
     meshgrid: AnyGeoDataFrame,
     weighting_spec: WeightingSpec,
 ) -> AnyGeoDataFrame:
-    from ecoscope.platform.tasks.analysis._calculate_feature_density import calculate_feature_density
-    from ecoscope.platform.tasks.transformation._classification import (
-        DefaultLabels,
-        SharedArgs,
-        apply_classification,
-    )
-
-    # copy: calculate_feature_density writes into the grid it is given, and the
-    # same meshgrid object is shared across mapvalues groups
     result = calculate_feature_density(
         geodataframe=geodataframe,
         meshgrid=meshgrid.copy(),
@@ -134,11 +134,6 @@ def _classified_ltd_density(
     meshgrid: AnyGeoDataFrame,
     weighting_spec: WeightingSpec,
 ) -> AnyGeoDataFrame:
-    from ecoscope import Trajectory
-    from ecoscope.analysis.classifier import classify_percentile
-    from ecoscope.analysis.linear_time_density import calculate_ltd
-    from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES
-
     density_grid = calculate_ltd(traj=Trajectory(geodataframe), grid=meshgrid.copy())
     if density_grid["density"].isna().all():
         return _empty_density_result(meshgrid)

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -19,6 +19,7 @@ class WeightingSpec:
     # "ltd": linear time density, percentile bins.
     mode: Literal["sum", "ltd"] = "sum"
     legend_label: str | None = None  # legend title prefix when it differs from option_label
+    percentiles: tuple[float, ...] | None = None  # "ltd" percentile bins; None -> LTD defaults
 
 
 def labeled_weighting(specs: dict[str, WeightingSpec]) -> Callable[[dict], None]:
@@ -131,6 +132,7 @@ def _classified_sum_density(
 def _classified_ltd_density(
     geodataframe: AnyGeoDataFrame,
     meshgrid: AnyGeoDataFrame,
+    weighting_spec: WeightingSpec,
 ) -> AnyGeoDataFrame:
     from ecoscope import Trajectory
     from ecoscope.analysis.classifier import classify_percentile
@@ -141,9 +143,10 @@ def _classified_ltd_density(
     if density_grid["density"].isna().all():
         return _empty_density_result(meshgrid)
 
+    percentiles = weighting_spec.percentiles or tuple(float(p) for p in LTD_DEFAULT_PERCENTILES)  # type: ignore[arg-type]
     result = classify_percentile(
         df=density_grid,
-        percentile_levels=[float(p) for p in LTD_DEFAULT_PERCENTILES],  # type: ignore[arg-type,misc]
+        percentile_levels=sorted(set(percentiles)),  # type: ignore[arg-type,misc]
         input_column_name="density",
     )
     result = result.dissolve(  # type: ignore[operator]
@@ -187,5 +190,5 @@ def calculate_classified_track_density(
         return _empty_density_result(meshgrid)
 
     if weighting_spec.mode == "ltd":
-        return _classified_ltd_density(geodataframe, meshgrid)
+        return _classified_ltd_density(geodataframe, meshgrid, weighting_spec)
     return _classified_sum_density(geodataframe, meshgrid, weighting_spec)

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 from wt_registry import register
@@ -15,6 +15,10 @@ class WeightingSpec:
     original_unit: Unit  # unit of the raw summed column
     display_unit: Unit  # unit shown on the map and in the legend title
     option_label: str  # form dropdown label and default legend title prefix
+    # "sum": per-cell column sum, equal-interval value bins;
+    # "ltd": linear time density, percentile bins.
+    mode: Literal["sum", "ltd"] = "sum"
+    legend_label: str | None = None  # legend title prefix when it differs from option_label
 
 
 def labeled_weighting(specs: dict[str, WeightingSpec]) -> Callable[[dict], None]:
@@ -58,7 +62,8 @@ def get_density_legend_title(
     """
     Legend title for the density map: the weighting's label and display unit.
     """
-    return f"{weighting_spec.option_label} ({weighting_spec.display_unit.value})"
+    label = weighting_spec.legend_label or weighting_spec.option_label
+    return f"{label} ({weighting_spec.display_unit.value})"
 
 
 @register()
@@ -72,3 +77,110 @@ def get_weighting_column(
     The gdf column the density is summed from.
     """
     return weighting_spec.density_sum_column
+
+
+def _empty_density_result(meshgrid: AnyGeoDataFrame) -> AnyGeoDataFrame:
+    import geopandas as gpd  # type: ignore[import-untyped]
+    import pandas as pd
+
+    return gpd.GeoDataFrame(
+        {"density": pd.Series(dtype="float64"), "density_bins": pd.Series(dtype="object")},
+        geometry=gpd.GeoSeries(dtype="geometry"),
+        crs=meshgrid.crs,
+    )
+
+
+def _classified_sum_density(
+    geodataframe: AnyGeoDataFrame,
+    meshgrid: AnyGeoDataFrame,
+    weighting_spec: WeightingSpec,
+) -> AnyGeoDataFrame:
+    from ecoscope.platform.tasks.analysis._calculate_feature_density import calculate_feature_density
+    from ecoscope.platform.tasks.transformation._classification import (
+        DefaultLabels,
+        SharedArgs,
+        apply_classification,
+    )
+
+    result = calculate_feature_density(
+        geodataframe=geodataframe,
+        meshgrid=meshgrid,
+        geometry_type="line",
+        sum_column=weighting_spec.density_sum_column,
+    )
+    result = normalize_density_units(df=result, weighting_spec=weighting_spec)
+    result = result.sort_values(by="density", ascending=True, na_position="last")
+    result = result[result["density"].notna()]
+    if result.empty:
+        return _empty_density_result(meshgrid)
+
+    return apply_classification(
+        df=result,
+        input_column_name="density",
+        output_column_name="density_bins",
+        label_options=DefaultLabels(label_ranges=True, label_decimals=1),
+        classification_options=SharedArgs(scheme="equal_interval", k=10),
+    )
+
+
+def _classified_ltd_density(
+    geodataframe: AnyGeoDataFrame,
+    meshgrid: AnyGeoDataFrame,
+) -> AnyGeoDataFrame:
+    from ecoscope import Trajectory
+    from ecoscope.analysis.classifier import classify_percentile
+    from ecoscope.analysis.linear_time_density import calculate_ltd
+    from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES
+
+    density_grid = calculate_ltd(traj=Trajectory(geodataframe), grid=meshgrid.copy())
+    if density_grid["density"].isna().all():
+        return _empty_density_result(meshgrid)
+
+    result = classify_percentile(
+        df=density_grid,
+        percentile_levels=[float(p) for p in LTD_DEFAULT_PERCENTILES],
+        input_column_name="density",
+    )
+    result = result.dissolve(
+        "percentile",
+        aggfunc={"density": "sum"},
+        as_index=False,
+    )
+    result = result[result["percentile"].notna()].sort_values(by="percentile", ascending=True)
+    result["density"] = result["percentile"]
+    # Patrols shows the suffix via the polygon layer's legend label_suffix (" %"),
+    # which is static in the spec; baking it into the labels keeps the spec
+    # mode-agnostic.
+    result["density_bins"] = result["percentile"].astype(str) + " %"
+    return result
+
+
+@register()
+def calculate_classified_track_density(
+    geodataframe: Annotated[
+        AnyGeoDataFrame,
+        Field(description="The trajectory segments to grid into a density surface.", exclude=True),
+    ],
+    meshgrid: Annotated[
+        AnyGeoDataFrame,
+        Field(description="The grid cells the density is calculated over.", exclude=True),
+    ],
+    weighting_spec: Annotated[
+        WeightingSpec,
+        Field(description="The weighting that selects the density calculation mode.", exclude=True),
+    ],
+) -> AnyGeoDataFrame:
+    """
+    Calculate a classified track density grid in the mode selected by the weighting.
+
+    Emits a uniform shape across modes: a 'density' column with the numeric
+    display value (display-unit sums for "sum" weightings, percentiles for
+    "ltd") and a 'density_bins' column with ready-to-render string bin labels,
+    sorted ascending with NaN cells dropped.
+    """
+    if geodataframe.empty:
+        return _empty_density_result(meshgrid)
+
+    if weighting_spec.mode == "ltd":
+        return _classified_ltd_density(geodataframe, meshgrid)
+    return _classified_sum_density(geodataframe, meshgrid, weighting_spec)

--- a/ecoscope/platform/tasks/analysis/_density_weighting.py
+++ b/ecoscope/platform/tasks/analysis/_density_weighting.py
@@ -1,25 +1,11 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Literal, TypeAlias, cast
+from typing import Annotated, Literal, TypeAlias
 
-import geopandas as gpd  # type: ignore[import-untyped]
-import pandas as pd
 from pydantic import Field
 from wt_registry import register
 
-from ecoscope import Trajectory
-from ecoscope.analysis.classifier import classify_percentile
-from ecoscope.analysis.linear_time_density import calculate_ltd
-from ecoscope.platform.annotations import AnyDataFrame, AnyGeoDataFrame
-from ecoscope.platform.tasks.analysis._calculate_feature_density import (
-    calculate_feature_density,
-)
-from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES
-from ecoscope.platform.tasks.transformation._classification import (
-    DefaultLabels,
-    SharedArgs,
-    apply_classification,
-)
+from ecoscope.platform.annotations import AnyGeoDataFrame
 from ecoscope.platform.tasks.transformation._unit import Unit, with_unit
 
 
@@ -132,109 +118,3 @@ def get_weighting_column(
     The gdf column the density is summed from.
     """
     return weighting_spec.density_sum_column
-
-
-def _empty_density_result(meshgrid: AnyGeoDataFrame) -> AnyGeoDataFrame:
-    return gpd.GeoDataFrame(
-        {
-            "density": pd.Series(dtype="float64"),
-            "density_bins": pd.Series(dtype="object"),
-        },
-        geometry=gpd.GeoSeries(dtype="geometry"),
-        crs=meshgrid.crs,
-    )
-
-
-def _classified_sum_density(
-    geodataframe: AnyGeoDataFrame,
-    meshgrid: AnyGeoDataFrame,
-    weighting_spec: SumWeightingSpec,
-) -> AnyGeoDataFrame:
-    result = calculate_feature_density(
-        geodataframe=geodataframe,
-        meshgrid=meshgrid.copy(),
-        geometry_type="line",
-        sum_column=weighting_spec.density_sum_column,
-    )
-    result = normalize_density_units(df=result, weighting_spec=weighting_spec)
-    result = result.sort_values(by="density", ascending=True, na_position="last")
-    result = result[result["density"].notna()]
-    if result.empty:
-        return _empty_density_result(meshgrid)
-
-    return cast(
-        AnyGeoDataFrame,
-        apply_classification(
-            df=cast(AnyDataFrame, result),
-            input_column_name="density",
-            output_column_name="density_bins",
-            label_options=DefaultLabels(label_ranges=True, label_decimals=1),
-            classification_options=SharedArgs(scheme="equal_interval", k=10),
-        ),
-    )
-
-
-def _classified_ud_density(
-    geodataframe: AnyGeoDataFrame,
-    meshgrid: AnyGeoDataFrame,
-    weighting_spec: UDWeightingSpec,
-) -> AnyGeoDataFrame:
-    density_grid = calculate_ltd(traj=Trajectory(geodataframe), grid=meshgrid.copy())
-    if density_grid["density"].isna().all():
-        return _empty_density_result(meshgrid)
-
-    percentiles = weighting_spec.percentiles or tuple(float(p) for p in LTD_DEFAULT_PERCENTILES)  # type: ignore[arg-type]
-    result = classify_percentile(
-        df=density_grid,
-        percentile_levels=sorted(set(percentiles)),  # type: ignore[arg-type,misc]
-        input_column_name="density",
-    )
-    result = result.dissolve(  # type: ignore[operator]
-        "percentile",
-        aggfunc={"density": "sum"},
-        as_index=False,
-    )
-    result = result[result["percentile"].notna()].sort_values(by="percentile", ascending=True)
-    result["density"] = result["percentile"]
-    # Patrols shows the suffix via the polygon layer's legend label_suffix (" %"),
-    # which is static in the spec; baking it into the labels keeps the spec
-    # mode-agnostic.
-    result["density_bins"] = result["percentile"].astype(str) + " %"
-    return result
-
-
-@register()
-def calculate_classified_track_density(
-    geodataframe: Annotated[
-        AnyGeoDataFrame,
-        Field(
-            description="The trajectory segments to grid into a density surface.",
-            exclude=True,
-        ),
-    ],
-    meshgrid: Annotated[
-        AnyGeoDataFrame,
-        Field(description="The grid cells the density is calculated over.", exclude=True),
-    ],
-    weighting_spec: Annotated[
-        WeightingSpec,
-        Field(
-            description="The weighting that selects the density calculation mode.",
-            exclude=True,
-        ),
-    ],
-) -> AnyGeoDataFrame:
-    """
-    Calculate a classified track density grid in the mode selected by the weighting.
-
-    Emits a uniform shape across modes: a 'density' column with the numeric
-    display value (display-unit sums for sum weightings, percentiles for UD)
-    and a 'density_bins' column with ready-to-render string bin labels,
-    sorted ascending with NaN cells dropped.
-    """
-    if geodataframe.empty:
-        return _empty_density_result(meshgrid)
-
-    if isinstance(weighting_spec, UDWeightingSpec):
-        return _classified_ud_density(geodataframe, meshgrid, weighting_spec)
-    return _classified_sum_density(geodataframe, meshgrid, weighting_spec)

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -1,9 +1,11 @@
+from dataclasses import replace
 from typing import Annotated, Literal, TypeAlias
 
 from pydantic import Field
 from wt_registry import register
 
 from ecoscope.platform.tasks.analysis._density_weighting import WeightingSpec, labeled_weighting
+from ecoscope.platform.tasks.analysis._time_density import LtdPercentileAnnotation
 from ecoscope.platform.tasks.transformation._unit import Unit
 
 PatrolDensityWeighting: TypeAlias = Literal["timespan_seconds", "dist_meters", "normalised_ltd"]
@@ -38,8 +40,16 @@ def set_patrol_weighting_spec(
             json_schema_extra=labeled_weighting(PATROL_WEIGHTING_SPECS),
         ),
     ] = "timespan_seconds",
+    percentiles: LtdPercentileAnnotation = None,
 ) -> WeightingSpec:
     """
     Select the weighting used for the patrol density grid.
+
+    `percentiles` only applies to the "ltd" weighting (the percentile bins to
+    display, as in the patrols workflow's Time Density Map); None keeps the
+    LTD defaults. Sum weightings ignore it.
     """
-    return PATROL_WEIGHTING_SPECS[density_sum_column]
+    spec = PATROL_WEIGHTING_SPECS[density_sum_column]
+    if percentiles:
+        spec = replace(spec, percentiles=tuple(float(p) for p in percentiles))
+    return spec

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -1,5 +1,5 @@
 from dataclasses import replace
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import Field
 from wt_registry import register
@@ -28,6 +28,28 @@ PATROL_WEIGHTING_SPECS: dict[str, WeightingSpec] = {
 }
 
 
+def _reveal_ltd_config_only_for_ltd(schema: dict[str, Any]) -> None:
+    """Move LTD-only fields behind an allOf/if/then keyed on the weighting choice.
+
+    Forms then only reveal Percentile Levels when "Normalised (LTD)" is
+    selected. The lenient shape is deliberate: no `additionalProperties`, and
+    no `default`/`minItems` on the conditional field — RJSF seeds hidden array
+    fields from the first render, so a default or minItems would leak values
+    or 422 submits in the non-LTD modes; the task falls back to the LTD
+    default percentiles when the value is omitted or empty.
+    """
+    percentiles = schema["properties"].pop("percentiles")
+    for key in ("default", "minItems", "ecoscope:advanced"):
+        percentiles.pop(key, None)
+    schema.pop("additionalProperties", None)
+    schema["allOf"] = [
+        {
+            "if": {"properties": {"density_sum_column": {"const": "normalised_ltd"}}},
+            "then": {"properties": {"percentiles": percentiles}},
+        }
+    ]
+
+
 @register()
 def set_patrol_weighting_spec(
     density_sum_column: Annotated[
@@ -53,3 +75,12 @@ def set_patrol_weighting_spec(
     if percentiles:
         spec = replace(spec, percentiles=tuple(float(p) for p in percentiles))
     return spec
+
+
+# Task-level schema hook (wt-registry >= the version adding
+# @register(json_schema_extra=...)). Set as an attribute rather than a
+# decorator kwarg so older wt-registry versions simply ignore it (the form
+# then shows percentiles unconditionally) instead of failing at import.
+set_patrol_weighting_spec.__wt_json_schema_extra__ = (  # type: ignore[attr-defined]
+    _reveal_ltd_config_only_for_ltd
+)

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -31,7 +31,10 @@ def set_patrol_weighting_spec(
     density_sum_column: Annotated[
         PatrolDensityWeighting,
         Field(
-            description="Weight each grid cell by total patrol time or distance travelled.",
+            description=(
+                "Weight each grid cell by total patrol time or distance travelled,"
+                " or by time normalised as a percentage of the total (LTD)."
+            ),
             json_schema_extra=labeled_weighting(PATROL_WEIGHTING_SPECS),
         ),
     ] = "timespan_seconds",

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -6,16 +6,23 @@ from wt_registry import register
 from ecoscope.platform.tasks.analysis._density_weighting import WeightingSpec, labeled_weighting
 from ecoscope.platform.tasks.transformation._unit import Unit
 
-PatrolDensityWeighting: TypeAlias = Literal["timespan_seconds", "dist_meters"]
+PatrolDensityWeighting: TypeAlias = Literal["timespan_seconds", "dist_meters", "normalised_ltd"]
 
-# Single source of truth per patrol weighting column; supporting a new
-# weighting is one entry here (plus the Literal above).
+# Single source of truth per patrol weighting; supporting a new weighting is
+# one entry here (plus the Literal above). Keys are the form dropdown values
+# and are independent of the sum column ("normalised_ltd" reuses
+# timespan_seconds).
 PATROL_WEIGHTING_SPECS: dict[str, WeightingSpec] = {
-    spec.density_sum_column: spec
-    for spec in (
-        WeightingSpec("timespan_seconds", Unit.SECOND, Unit.HOUR, "Time"),
-        WeightingSpec("dist_meters", Unit.METER, Unit.KILOMETER, "Distance"),
-    )
+    "timespan_seconds": WeightingSpec("timespan_seconds", Unit.SECOND, Unit.HOUR, "Time"),
+    "dist_meters": WeightingSpec("dist_meters", Unit.METER, Unit.KILOMETER, "Distance"),
+    "normalised_ltd": WeightingSpec(
+        "timespan_seconds",
+        Unit.SECOND,
+        Unit.PERCENT,
+        "Normalised (LTD)",
+        mode="ltd",
+        legend_label="Time Spent",
+    ),
 }
 
 

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -1,11 +1,12 @@
 from dataclasses import replace
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Literal, TypeAlias, get_args
 
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
 
 from ecoscope.platform.tasks.analysis._density_weighting import WeightingSpec, labeled_weighting
-from ecoscope.platform.tasks.analysis._time_density import LtdPercentileAnnotation
+from ecoscope.platform.tasks.analysis._time_density import UDPercentiles
 from ecoscope.platform.tasks.transformation._unit import Unit
 
 PatrolDensityWeighting: TypeAlias = Literal["timespan_seconds", "dist_meters", "normalised_ltd"]
@@ -28,59 +29,84 @@ PATROL_WEIGHTING_SPECS: dict[str, WeightingSpec] = {
 }
 
 
-def _reveal_ltd_config_only_for_ltd(schema: dict[str, Any]) -> None:
-    """Move LTD-only fields behind an allOf/if/then keyed on the weighting choice.
+class PatrolWeightingSelection(BaseModel):
+    """Density calculation choice; selecting Normalised (LTD) reveals its percentile levels."""
 
-    Forms then only reveal Percentile Levels when "Normalised (LTD)" is
-    selected. The lenient shape is deliberate: no `additionalProperties`, and
-    no `default`/`minItems` on the conditional field — RJSF seeds hidden array
-    fields from the first render, so a default or minItems would leak values
-    or 422 submits in the non-LTD modes; the task falls back to the LTD
-    default percentiles when the value is omitted or empty.
-    """
-    percentiles = schema["properties"].pop("percentiles")
-    for key in ("default", "minItems", "ecoscope:advanced"):
-        percentiles.pop(key, None)
-    schema.pop("additionalProperties", None)
-    schema["allOf"] = [
-        {
-            "if": {"properties": {"density_sum_column": {"const": "normalised_ltd"}}},
-            "then": {"properties": {"percentiles": percentiles}},
-        }
-    ]
-
-
-@register()
-def set_patrol_weighting_spec(
+    model_config = ConfigDict(
+        title="",
+        json_schema_extra={
+            "dependencies": {
+                "density_sum_column": {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "density_sum_column": {"enum": ["timespan_seconds", "dist_meters"]},
+                            }
+                        },
+                        {
+                            "properties": {
+                                "density_sum_column": {"const": "normalised_ltd"},
+                                # No `default` or `minItems` here: a default on a
+                                # dependency branch gets seeded into formData even
+                                # while another option is selected, leaving an
+                                # orphaned value behind; the task falls back to the
+                                # LTD default percentiles when omitted or empty.
+                                "percentiles": {
+                                    "title": "Percentile Levels",
+                                    "description": "Choose the time density percentile bins to display.",
+                                    "type": "array",
+                                    "uniqueItems": True,
+                                    "items": {"type": "string", "enum": list(get_args(UDPercentiles))},
+                                },
+                            }
+                        },
+                    ]
+                }
+            }
+        },
+    )
     density_sum_column: Annotated[
         PatrolDensityWeighting,
         Field(
+            title="Density Calculation",
             description=(
                 "Weight each grid cell by total patrol time or distance travelled,"
                 " or by time normalised as a percentage of the total (LTD)."
             ),
             json_schema_extra=labeled_weighting(PATROL_WEIGHTING_SPECS),
         ),
-    ] = "timespan_seconds",
-    percentiles: LtdPercentileAnnotation = None,
+    ] = "timespan_seconds"
+    percentiles: SkipJsonSchema[list[float] | None] = None
+
+    @model_validator(mode="after")
+    def clear_orphaned_percentiles(self):
+        # percentiles left behind by switching away from LTD in the form are ignored
+        if self.density_sum_column != "normalised_ltd":
+            self.percentiles = None
+        return self
+
+
+@register()
+def set_patrol_weighting_spec(
+    weighting: Annotated[
+        PatrolWeightingSelection | SkipJsonSchema[None],
+        Field(
+            default=None,
+            title="",
+            json_schema_extra={"default": {"density_sum_column": "timespan_seconds"}},
+        ),
+    ] = None,
 ) -> WeightingSpec:
     """
     Select the weighting used for the patrol density grid.
 
-    `percentiles` only applies to the "ltd" weighting (the percentile bins to
-    display, as in the patrols workflow's Time Density Map); None keeps the
-    LTD defaults. Sum weightings ignore it.
+    Percentile levels only apply to the "ltd" weighting (the percentile bins
+    to display, as in the patrols workflow's Time Density Map); None keeps the
+    LTD defaults. Sum weightings ignore them.
     """
-    spec = PATROL_WEIGHTING_SPECS[density_sum_column]
-    if percentiles:
-        spec = replace(spec, percentiles=tuple(float(p) for p in percentiles))
+    if weighting is None:
+        weighting = PatrolWeightingSelection()
+    spec = PATROL_WEIGHTING_SPECS[weighting.density_sum_column]
+    if weighting.percentiles:
+        spec = replace(spec, percentiles=tuple(weighting.percentiles))
     return spec
-
-
-# Task-level schema hook (wt-registry >= the version adding
-# @register(json_schema_extra=...)). Set as an attribute rather than a
-# decorator kwarg so older wt-registry versions simply ignore it (the form
-# then shows percentiles unconditionally) instead of failing at import.
-set_patrol_weighting_spec.__wt_json_schema_extra__ = (  # type: ignore[attr-defined]
-    _reveal_ltd_config_only_for_ltd
-)

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -29,35 +29,28 @@ class PatrolWeightingSelection(BaseModel):
     model_config = ConfigDict(
         title="",
         json_schema_extra={
-            "dependencies": {
-                "density_sum_column": {
-                    "oneOf": [
-                        {
-                            "properties": {
-                                "density_sum_column": {"enum": ["timespan_seconds", "dist_meters"]},
-                            }
-                        },
-                        {
-                            "properties": {
-                                "density_sum_column": {"const": "normalised_ltd"},
-                                # No `default` here: RJSF resolves dependency
-                                # branches when rendering but never copies their
-                                # defaults into formData, so a branch default
-                                # would show an empty picker. The pre-fill
-                                # instead rides on set_patrol_weighting_spec's
-                                # param-level object default.
-                                "percentiles": {
-                                    "title": "Percentile Levels",
-                                    "description": "Choose the time density percentile bins to display.",
-                                    "type": "array",
-                                    "uniqueItems": True,
-                                    "items": {"type": "string", "enum": list(get_args(UDPercentiles))},
-                                },
-                            }
-                        },
-                    ]
+            "allOf": [
+                {
+                    "if": {"properties": {"density_sum_column": {"const": "normalised_ltd"}}},
+                    "then": {
+                        "properties": {
+                            # No `default` here: RJSF resolves conditional
+                            # branches when rendering but never copies their
+                            # defaults into formData, so a branch default
+                            # would show an empty picker. The pre-fill
+                            # instead rides on set_patrol_weighting_spec's
+                            # param-level object default.
+                            "percentiles": {
+                                "title": "Percentile Levels",
+                                "description": "Choose the time density percentile bins to display.",
+                                "type": "array",
+                                "uniqueItems": True,
+                                "items": {"type": "string", "enum": list(get_args(UDPercentiles))},
+                            },
+                        }
+                    },
                 }
-            }
+            ]
         },
     )
     density_sum_column: Annotated[

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -5,27 +5,23 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
 
-from ecoscope.platform.tasks.analysis._density_weighting import WeightingSpec, labeled_weighting
+from ecoscope.platform.tasks.analysis._density_weighting import (
+    SumWeightingSpec,
+    UDWeightingSpec,
+    WeightingSpec,
+    labeled_weighting,
+)
 from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES, UDPercentiles
 from ecoscope.platform.tasks.transformation._unit import Unit
 
 PatrolDensityWeighting: TypeAlias = Literal["timespan_seconds", "dist_meters", "normalised_ltd"]
 
 # Single source of truth per patrol weighting; supporting a new weighting is
-# one entry here (plus the Literal above). Keys are the form dropdown values
-# and are independent of the sum column ("normalised_ltd" reuses
-# timespan_seconds).
+# one entry here (plus the Literal above). Keys are the form dropdown values.
 PATROL_WEIGHTING_SPECS: dict[str, WeightingSpec] = {
-    "timespan_seconds": WeightingSpec("timespan_seconds", Unit.SECOND, Unit.HOUR, "Time"),
-    "dist_meters": WeightingSpec("dist_meters", Unit.METER, Unit.KILOMETER, "Distance"),
-    "normalised_ltd": WeightingSpec(
-        "timespan_seconds",
-        Unit.SECOND,
-        Unit.PERCENT,
-        "Normalised (LTD)",
-        mode="ltd",
-        legend_label="Time Spent",
-    ),
+    "timespan_seconds": SumWeightingSpec("timespan_seconds", Unit.SECOND, Unit.HOUR, "Time"),
+    "dist_meters": SumWeightingSpec("dist_meters", Unit.METER, Unit.KILOMETER, "Distance"),
+    "normalised_ltd": UDWeightingSpec(option_label="Normalised (LTD)", legend_label="Time Spent"),
 }
 
 
@@ -108,13 +104,13 @@ def set_patrol_weighting_spec(
     """
     Select the weighting used for the patrol density grid.
 
-    Percentile levels only apply to the "ltd" weighting (the percentile bins
+    Percentile levels only apply to the UD weighting (the percentile bins
     to display, as in the patrols workflow's Time Density Map); None keeps the
     LTD defaults. Sum weightings ignore them.
     """
     if weighting is None:
         weighting = PatrolWeightingSelection()
     spec = PATROL_WEIGHTING_SPECS[weighting.density_sum_column]
-    if weighting.percentiles:
+    if isinstance(spec, UDWeightingSpec) and weighting.percentiles:
         spec = replace(spec, percentiles=tuple(weighting.percentiles))
     return spec

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -6,7 +6,7 @@ from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
 
 from ecoscope.platform.tasks.analysis._density_weighting import WeightingSpec, labeled_weighting
-from ecoscope.platform.tasks.analysis._time_density import UDPercentiles
+from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES, UDPercentiles
 from ecoscope.platform.tasks.transformation._unit import Unit
 
 PatrolDensityWeighting: TypeAlias = Literal["timespan_seconds", "dist_meters", "normalised_ltd"]
@@ -30,8 +30,6 @@ PATROL_WEIGHTING_SPECS: dict[str, WeightingSpec] = {
 
 
 class PatrolWeightingSelection(BaseModel):
-    """Density calculation choice; selecting Normalised (LTD) reveals its percentile levels."""
-
     model_config = ConfigDict(
         title="",
         json_schema_extra={
@@ -46,15 +44,18 @@ class PatrolWeightingSelection(BaseModel):
                         {
                             "properties": {
                                 "density_sum_column": {"const": "normalised_ltd"},
-                                # No `default` or `minItems` here: a default on a
-                                # dependency branch gets seeded into formData even
-                                # while another option is selected, leaving an
-                                # orphaned value behind; the task falls back to the
-                                # LTD default percentiles when omitted or empty.
+                                # The default pre-fills the picker like the patrols
+                                # workflow's Time Density Map. RJSF may seed it into
+                                # formData even while another option is selected;
+                                # that orphan is harmless here — nothing in this
+                                # lenient schema rejects it (no minItems /
+                                # additionalProperties) and clear_orphaned_percentiles
+                                # discards it for non-LTD selections.
                                 "percentiles": {
                                     "title": "Percentile Levels",
                                     "description": "Choose the time density percentile bins to display.",
                                     "type": "array",
+                                    "default": list(LTD_DEFAULT_PERCENTILES),
                                     "uniqueItems": True,
                                     "items": {"type": "string", "enum": list(get_args(UDPercentiles))},
                                 },

--- a/ecoscope/platform/tasks/analysis/_patrol_density.py
+++ b/ecoscope/platform/tasks/analysis/_patrol_density.py
@@ -44,18 +44,16 @@ class PatrolWeightingSelection(BaseModel):
                         {
                             "properties": {
                                 "density_sum_column": {"const": "normalised_ltd"},
-                                # The default pre-fills the picker like the patrols
-                                # workflow's Time Density Map. RJSF may seed it into
-                                # formData even while another option is selected;
-                                # that orphan is harmless here — nothing in this
-                                # lenient schema rejects it (no minItems /
-                                # additionalProperties) and clear_orphaned_percentiles
-                                # discards it for non-LTD selections.
+                                # No `default` here: RJSF resolves dependency
+                                # branches when rendering but never copies their
+                                # defaults into formData, so a branch default
+                                # would show an empty picker. The pre-fill
+                                # instead rides on set_patrol_weighting_spec's
+                                # param-level object default.
                                 "percentiles": {
                                     "title": "Percentile Levels",
                                     "description": "Choose the time density percentile bins to display.",
                                     "type": "array",
-                                    "default": list(LTD_DEFAULT_PERCENTILES),
                                     "uniqueItems": True,
                                     "items": {"type": "string", "enum": list(get_args(UDPercentiles))},
                                 },
@@ -94,7 +92,16 @@ def set_patrol_weighting_spec(
         Field(
             default=None,
             title="",
-            json_schema_extra={"default": {"density_sum_column": "timespan_seconds"}},
+            # percentiles seeded here (the patrols Time Density Map defaults)
+            # so the picker comes pre-filled when Normalised (LTD) is selected;
+            # while another option is selected it sits hidden in formData and
+            # clear_orphaned_percentiles discards it server-side.
+            json_schema_extra={
+                "default": {
+                    "density_sum_column": "timespan_seconds",
+                    "percentiles": list(LTD_DEFAULT_PERCENTILES),
+                }
+            },
         ),
     ] = None,
 ) -> WeightingSpec:

--- a/ecoscope/platform/tasks/analysis/_summary.py
+++ b/ecoscope/platform/tasks/analysis/_summary.py
@@ -26,15 +26,6 @@ AggOperations = Literal[
 class _BaseSummaryParam(BaseModel):
     display_name: Annotated[str, Field(title="Display Name", description="Column header shown in the summary table.")]
 
-
-# The unit fields are excluded from the model's own JSON schema (SkipJsonSchema)
-# and re-introduced via the allOf/if/then block in json_schema_extra, so the form
-# only shows them once "Convert Units" is checked. if/then (not the legacy
-# `dependencies` keyword) is understood by BOTH the RJSF renderer and JSON Schema
-# 2020-12 validators (ecoscope-server validates submitted formdata with
-# Draft202012Validator, which silently ignores `dependencies`). See
-# wildlife-dynamics/wt-download-subject-tracks#31 for the full dialect story.
-# Note the docstring renders as the form's helper text.
 class StatSummaryParam(_BaseSummaryParam):
     """Pick a column and statistic, with optional unit conversion."""
 

--- a/ecoscope/platform/tasks/analysis/_summary.py
+++ b/ecoscope/platform/tasks/analysis/_summary.py
@@ -26,6 +26,7 @@ AggOperations = Literal[
 class _BaseSummaryParam(BaseModel):
     display_name: Annotated[str, Field(title="Display Name", description="Column header shown in the summary table.")]
 
+
 class StatSummaryParam(_BaseSummaryParam):
     """Pick a column and statistic, with optional unit conversion."""
 

--- a/ecoscope/platform/tasks/analysis/_track_density.py
+++ b/ecoscope/platform/tasks/analysis/_track_density.py
@@ -1,0 +1,121 @@
+from typing import Annotated, cast
+
+import geopandas as gpd  # type: ignore[import-untyped]
+import pandas as pd
+from pydantic import Field
+from wt_registry import register
+
+from ecoscope import Trajectory
+from ecoscope.analysis.classifier import classify_percentile
+from ecoscope.analysis.linear_time_density import calculate_ltd
+from ecoscope.platform.annotations import AnyDataFrame, AnyGeoDataFrame
+from ecoscope.platform.tasks.analysis._calculate_feature_density import calculate_feature_density
+from ecoscope.platform.tasks.analysis._density_weighting import (
+    SumWeightingSpec,
+    UDWeightingSpec,
+    WeightingSpec,
+    normalize_density_units,
+)
+from ecoscope.platform.tasks.analysis._time_density import LTD_DEFAULT_PERCENTILES
+from ecoscope.platform.tasks.transformation._classification import (
+    DefaultLabels,
+    SharedArgs,
+    apply_classification,
+)
+
+
+def _empty_density_result(meshgrid: AnyGeoDataFrame) -> AnyGeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"density": pd.Series(dtype="float64"), "density_bins": pd.Series(dtype="object")},
+        geometry=gpd.GeoSeries(dtype="geometry"),
+        crs=meshgrid.crs,
+    )
+
+
+def _classified_sum_density(
+    geodataframe: AnyGeoDataFrame,
+    meshgrid: AnyGeoDataFrame,
+    weighting_spec: SumWeightingSpec,
+) -> AnyGeoDataFrame:
+    result = calculate_feature_density(
+        geodataframe=geodataframe,
+        meshgrid=meshgrid.copy(),
+        geometry_type="line",
+        sum_column=weighting_spec.density_sum_column,
+    )
+    result = normalize_density_units(df=result, weighting_spec=weighting_spec)
+    result = result.sort_values(by="density", ascending=True, na_position="last")
+    result = result[result["density"].notna()]
+    if result.empty:
+        return _empty_density_result(meshgrid)
+
+    return cast(
+        AnyGeoDataFrame,
+        apply_classification(
+            df=cast(AnyDataFrame, result),
+            input_column_name="density",
+            output_column_name="density_bins",
+            label_options=DefaultLabels(label_ranges=True, label_decimals=1),
+            classification_options=SharedArgs(scheme="equal_interval", k=10),
+        ),
+    )
+
+
+def _classified_ud_density(
+    geodataframe: AnyGeoDataFrame,
+    meshgrid: AnyGeoDataFrame,
+    weighting_spec: UDWeightingSpec,
+) -> AnyGeoDataFrame:
+    density_grid = calculate_ltd(traj=Trajectory(geodataframe), grid=meshgrid.copy())
+    if density_grid["density"].isna().all():
+        return _empty_density_result(meshgrid)
+
+    percentiles = weighting_spec.percentiles or tuple(float(p) for p in LTD_DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+    result = classify_percentile(
+        df=density_grid,
+        percentile_levels=sorted(set(percentiles)),  # type: ignore[arg-type,misc]
+        input_column_name="density",
+    )
+    result = result.dissolve(  # type: ignore[operator]
+        "percentile",
+        aggfunc={"density": "sum"},
+        as_index=False,
+    )
+    result = result[result["percentile"].notna()].sort_values(by="percentile", ascending=True)
+    result["density"] = result["percentile"]
+    # Patrols shows the suffix via the polygon layer's legend label_suffix (" %"),
+    # which is static in the spec; baking it into the labels keeps the spec
+    # mode-agnostic.
+    result["density_bins"] = result["percentile"].astype(str) + " %"
+    return result
+
+
+@register()
+def calculate_classified_track_density(
+    geodataframe: Annotated[
+        AnyGeoDataFrame,
+        Field(description="The trajectory segments to grid into a density surface.", exclude=True),
+    ],
+    meshgrid: Annotated[
+        AnyGeoDataFrame,
+        Field(description="The grid cells the density is calculated over.", exclude=True),
+    ],
+    weighting_spec: Annotated[
+        WeightingSpec,
+        Field(description="The weighting that selects the density calculation mode.", exclude=True),
+    ],
+) -> AnyGeoDataFrame:
+    """
+    Calculate a classified track density grid in the mode selected by the weighting.
+
+    Emits a uniform shape across modes: a 'density' column with the numeric
+    display value (display-unit sums for sum weightings, percentiles for UD)
+    and a 'density_bins' column with ready-to-render string bin labels,
+    sorted ascending with NaN cells dropped.
+    """
+    if geodataframe.empty:
+        return _empty_density_result(meshgrid)
+
+    if isinstance(weighting_spec, UDWeightingSpec):
+        return _classified_ud_density(geodataframe, meshgrid, weighting_spec)
+    return _classified_sum_density(geodataframe, meshgrid, weighting_spec)

--- a/ecoscope/platform/tasks/config/__init__.py
+++ b/ecoscope/platform/tasks/config/__init__.py
@@ -29,6 +29,7 @@ from ._set_vars import (
     prefix_string_var,
     set_bool_var,
     set_list_of_string_vars,
+    set_optional_string_var,
     set_string_var,
     title_case_var,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "prefix_string_var",
     "set_bool_var",
     "set_list_of_string_vars",
+    "set_optional_string_var",
     "set_string_var",
     "title_case_var",
     "WorkflowDetails",

--- a/ecoscope/platform/tasks/config/_set_vars.py
+++ b/ecoscope/platform/tasks/config/_set_vars.py
@@ -15,6 +15,13 @@ def set_string_var(
 
 
 @register()
+def set_optional_string_var(
+    var: Annotated[str, Field(title="")] = "",
+) -> str:
+    return var
+
+
+@register()
 def set_bool_var(
     var: Annotated[bool, Field(title="")],
 ) -> bool:

--- a/ecoscope/platform/tasks/transformation/_unit.py
+++ b/ecoscope/platform/tasks/transformation/_unit.py
@@ -17,7 +17,8 @@ class Unit(Enum):
     DAY = "d"
     METERS_PER_SECOND = "m/s"
     KILOMETERS_PER_HOUR = "km/h"
-    # Display-only label; never routed through astropy conversion.
+    # Display-only by convention: nothing here forbids conversion, but astropy
+    # raises for any target other than a dimensionless one.
     PERCENT = "%"
 
     def __str__(self) -> str:

--- a/ecoscope/platform/tasks/transformation/_unit.py
+++ b/ecoscope/platform/tasks/transformation/_unit.py
@@ -17,6 +17,8 @@ class Unit(Enum):
     DAY = "d"
     METERS_PER_SECOND = "m/s"
     KILOMETERS_PER_HOUR = "km/h"
+    # Display-only label; never routed through astropy conversion.
+    PERCENT = "%"
 
     def __str__(self) -> str:
         return self.value
@@ -34,6 +36,7 @@ UNIT_LABELS: dict[Unit, str] = {
     Unit.DAY: "Days (d)",
     Unit.METERS_PER_SECOND: "Meters per Second (m/s)",
     Unit.KILOMETERS_PER_HOUR: "Kilometers per Hour (km/h)",
+    Unit.PERCENT: "Percent (%)",
 }
 
 UNIT_OPTIONS: list[JsonValue] = [{"const": unit.value, "title": title} for unit, title in UNIT_LABELS.items()]

--- a/tests/platform/tasks/test_calculate_feature_density.py
+++ b/tests/platform/tasks/test_calculate_feature_density.py
@@ -1,4 +1,5 @@
 import geopandas as gpd  # type: ignore[import-untyped]
+import pytest
 
 from ecoscope.platform.tasks.analysis import (
     calculate_feature_density,
@@ -78,8 +79,6 @@ def test_calculate_feature_density_sum_column_coerced_to_numeric():
 
 
 def test_calculate_feature_density_missing_sum_column_raises():
-    import pytest
-
     bounds = random_3857_rectangle(500, 500, 500, 500, utm_safe=True)
 
     aoi = gpd.GeoDataFrame(geometry=[bounds], crs="EPSG:3857")

--- a/tests/platform/tasks/test_calculate_feature_density.py
+++ b/tests/platform/tasks/test_calculate_feature_density.py
@@ -30,3 +30,70 @@ def test_calculate_feature_density():
 
     # the sum of all density vals should equal our number of points
     assert result.density.sum() == 200
+
+
+def test_calculate_feature_density_empty_sum_column_counts():
+    bounds = random_3857_rectangle(500, 500, 500, 500, utm_safe=True)
+
+    aoi = gpd.GeoDataFrame(geometry=[bounds], crs="EPSG:3857")
+    meshgrid = create_meshgrid(
+        aoi,
+        auto_scale_or_custom_cell_size=CustomGridCellSize(grid_cell_size=100),
+    )
+    random_points = random_points_in_bounds(bounds, 200)
+    points_gdf = gpd.GeoDataFrame(geometry=random_points, crs="EPSG:3857")
+
+    result = calculate_feature_density(
+        geodataframe=points_gdf,
+        meshgrid=meshgrid,
+        geometry_type="point",
+        sum_column="",
+    )
+
+    # empty string behaves like None: count rows per cell
+    assert result.density.sum() == 200
+
+
+def test_calculate_feature_density_sum_column_coerced_to_numeric():
+    bounds = random_3857_rectangle(500, 500, 500, 500, utm_safe=True)
+
+    aoi = gpd.GeoDataFrame(geometry=[bounds], crs="EPSG:3857")
+    meshgrid = create_meshgrid(
+        aoi,
+        auto_scale_or_custom_cell_size=CustomGridCellSize(grid_cell_size=100),
+    )
+    random_points = random_points_in_bounds(bounds, 200)
+    points_gdf = gpd.GeoDataFrame(geometry=random_points, crs="EPSG:3857")
+    # string-typed numbers, with one non-castable value that should be ignored
+    points_gdf["Number of Animals"] = ["2"] * 199 + ["n/a"]
+
+    result = calculate_feature_density(
+        geodataframe=points_gdf,
+        meshgrid=meshgrid,
+        geometry_type="point",
+        sum_column="Number of Animals",
+    )
+
+    assert result.density.sum() == 398
+
+
+def test_calculate_feature_density_missing_sum_column_raises():
+    import pytest
+
+    bounds = random_3857_rectangle(500, 500, 500, 500, utm_safe=True)
+
+    aoi = gpd.GeoDataFrame(geometry=[bounds], crs="EPSG:3857")
+    meshgrid = create_meshgrid(
+        aoi,
+        auto_scale_or_custom_cell_size=CustomGridCellSize(grid_cell_size=100),
+    )
+    random_points = random_points_in_bounds(bounds, 10)
+    points_gdf = gpd.GeoDataFrame(geometry=random_points, crs="EPSG:3857")
+
+    with pytest.raises(ValueError, match="not found in the feature data"):
+        calculate_feature_density(
+            geodataframe=points_gdf,
+            meshgrid=meshgrid,
+            geometry_type="point",
+            sum_column="No Such Column",
+        )

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -1,17 +1,48 @@
 import math
+from importlib.resources import files
 
 import geopandas as gpd  # type: ignore[import-untyped]
 import numpy as np
+import pytest
 from shapely.geometry import box
 
 from ecoscope.platform.tasks.analysis import (
+    calculate_classified_track_density,
+    calculate_feature_density,
+    calculate_linear_time_density,
     get_density_legend_title,
     get_weighting_column,
     normalize_density_units,
     set_patrol_weighting_spec,
 )
+from ecoscope.platform.tasks.analysis._create_meshgrid import create_meshgrid
 from ecoscope.platform.tasks.analysis._density_weighting import labeled_weighting
 from ecoscope.platform.tasks.analysis._patrol_density import PATROL_WEIGHTING_SPECS
+from ecoscope.platform.tasks.analysis._time_density import AutoScaleGridCellSize
+from ecoscope.platform.tasks.transformation._classification import (
+    DefaultLabels,
+    SharedArgs,
+    apply_classification,
+)
+from ecoscope.platform.tasks.transformation._filtering import drop_nan_values_by_column
+from ecoscope.platform.tasks.transformation._sorting import sort_values
+from ecoscope.platform.tasks.transformation._unit import Unit
+
+
+@pytest.fixture
+def trajectory_gdf():
+    example_input_df_path = (
+        files("ecoscope.platform.tasks.preprocessing") / "relocations-to-trajectory.example-return.parquet"
+    )
+    return gpd.read_parquet(example_input_df_path)
+
+
+@pytest.fixture
+def meshgrid(trajectory_gdf):
+    return create_meshgrid(
+        aoi=trajectory_gdf,
+        auto_scale_or_custom_cell_size=AutoScaleGridCellSize(),
+    )
 
 
 def test_set_patrol_weighting_spec():
@@ -19,11 +50,37 @@ def test_set_patrol_weighting_spec():
         set_patrol_weighting_spec(density_sum_column="timespan_seconds") is PATROL_WEIGHTING_SPECS["timespan_seconds"]
     )
     assert set_patrol_weighting_spec(density_sum_column="dist_meters") is PATROL_WEIGHTING_SPECS["dist_meters"]
+    assert set_patrol_weighting_spec(density_sum_column="normalised_ltd") is PATROL_WEIGHTING_SPECS["normalised_ltd"]
+
+
+def test_sum_specs_unchanged():
+    time_spec = PATROL_WEIGHTING_SPECS["timespan_seconds"]
+    assert (time_spec.density_sum_column, time_spec.original_unit, time_spec.display_unit) == (
+        "timespan_seconds",
+        Unit.SECOND,
+        Unit.HOUR,
+    )
+    assert (time_spec.option_label, time_spec.mode) == ("Time", "sum")
+    dist_spec = PATROL_WEIGHTING_SPECS["dist_meters"]
+    assert (dist_spec.density_sum_column, dist_spec.original_unit, dist_spec.display_unit) == (
+        "dist_meters",
+        Unit.METER,
+        Unit.KILOMETER,
+    )
+    assert (dist_spec.option_label, dist_spec.mode) == ("Distance", "sum")
+
+
+def test_ltd_spec():
+    ltd_spec = PATROL_WEIGHTING_SPECS["normalised_ltd"]
+    assert ltd_spec.density_sum_column == "timespan_seconds"
+    assert (ltd_spec.original_unit, ltd_spec.display_unit) == (Unit.SECOND, Unit.PERCENT)
+    assert (ltd_spec.option_label, ltd_spec.mode) == ("Normalised (LTD)", "ltd")
 
 
 def test_get_weighting_column():
     assert get_weighting_column(weighting_spec=PATROL_WEIGHTING_SPECS["timespan_seconds"]) == "timespan_seconds"
     assert get_weighting_column(weighting_spec=PATROL_WEIGHTING_SPECS["dist_meters"]) == "dist_meters"
+    assert get_weighting_column(weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"]) == "timespan_seconds"
 
 
 def test_normalize_density_units_time():
@@ -52,13 +109,79 @@ def test_normalize_density_units_distance():
 def test_get_density_legend_title():
     assert get_density_legend_title(weighting_spec=PATROL_WEIGHTING_SPECS["timespan_seconds"]) == "Time (h)"
     assert get_density_legend_title(weighting_spec=PATROL_WEIGHTING_SPECS["dist_meters"]) == "Distance (km)"
+    assert get_density_legend_title(weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"]) == "Time Spent (%)"
 
 
 def test_labeled_weighting_replaces_enum_with_labeled_options():
-    schema = {"enum": ["timespan_seconds", "dist_meters"]}
+    schema = {"enum": ["timespan_seconds", "dist_meters", "normalised_ltd"]}
     labeled_weighting(PATROL_WEIGHTING_SPECS)(schema)
     assert "enum" not in schema
     assert schema["oneOf"] == [
         {"const": "timespan_seconds", "title": "Time"},
         {"const": "dist_meters", "title": "Distance"},
+        {"const": "normalised_ltd", "title": "Normalised (LTD)"},
     ]
+
+
+@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters"])
+def test_classified_track_density_sum_matches_legacy_pipeline(trajectory_gdf, meshgrid, weighting):
+    spec = PATROL_WEIGHTING_SPECS[weighting]
+
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid,
+        weighting_spec=spec,
+    )
+
+    legacy = calculate_feature_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid.copy(),
+        geometry_type="line",
+        sum_column=spec.density_sum_column,
+    )
+    legacy = normalize_density_units(df=legacy, weighting_spec=spec)
+    legacy = sort_values(df=legacy, column_name="density", ascending=True, na_position="last")
+    legacy = drop_nan_values_by_column(df=legacy, column_name="density")
+    legacy = apply_classification(
+        df=legacy,
+        input_column_name="density",
+        output_column_name="density_bins",
+        label_options=DefaultLabels(label_ranges=True, label_decimals=1),
+        classification_options=SharedArgs(scheme="equal_interval", k=10),
+    )
+
+    assert len(result) > 0
+    assert list(result["density"]) == list(legacy["density"])
+    assert list(result["density_bins"]) == list(legacy["density_bins"])
+    assert list(result.geometry) == list(legacy.geometry)
+
+
+def test_classified_track_density_ltd_matches_linear_time_density(trajectory_gdf, meshgrid):
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid,
+        weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"],
+    )
+
+    expected = calculate_linear_time_density(
+        trajectory_gdf=trajectory_gdf,
+        meshgrid=meshgrid.copy(),
+    )
+
+    assert len(result) == len(expected)
+    assert list(result["density"]) == sorted(expected["percentile"])
+    assert list(result["density_bins"]) == [f"{p} %" for p in result["density"]]
+    expected_geoms = expected.sort_values("percentile").geometry
+    assert all(a.equals(b) for a, b in zip(result.geometry, expected_geoms))
+
+
+@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters", "normalised_ltd"])
+def test_classified_track_density_empty_trajectory(trajectory_gdf, meshgrid, weighting):
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf.iloc[0:0],
+        meshgrid=meshgrid,
+        weighting_spec=PATROL_WEIGHTING_SPECS[weighting],
+    )
+    assert result.empty
+    assert "density" in result.columns
+    assert "density_bins" in result.columns

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -1,22 +1,16 @@
 import math
-from importlib.resources import files
 
 import geopandas as gpd  # type: ignore[import-untyped]
 import numpy as np
-import pytest
 from shapely.geometry import box
 
 from ecoscope.platform.tasks.analysis import (
-    calculate_classified_track_density,
-    calculate_feature_density,
-    calculate_linear_time_density,
     get_density_colormap,
     get_density_legend_title,
     get_weighting_column,
     normalize_density_units,
     set_patrol_weighting_spec,
 )
-from ecoscope.platform.tasks.analysis._create_meshgrid import create_meshgrid
 from ecoscope.platform.tasks.analysis._density_weighting import (
     SumWeightingSpec,
     UDWeightingSpec,
@@ -26,31 +20,7 @@ from ecoscope.platform.tasks.analysis._patrol_density import (
     PATROL_WEIGHTING_SPECS,
     PatrolWeightingSelection,
 )
-from ecoscope.platform.tasks.analysis._time_density import AutoScaleGridCellSize
-from ecoscope.platform.tasks.transformation._classification import (
-    DefaultLabels,
-    SharedArgs,
-    apply_classification,
-)
-from ecoscope.platform.tasks.transformation._filtering import drop_nan_values_by_column
-from ecoscope.platform.tasks.transformation._sorting import sort_values
 from ecoscope.platform.tasks.transformation._unit import Unit
-
-
-@pytest.fixture
-def trajectory_gdf():
-    example_input_df_path = (
-        files("ecoscope.platform.tasks.preprocessing") / "relocations-to-trajectory.example-return.parquet"
-    )
-    return gpd.read_parquet(example_input_df_path)
-
-
-@pytest.fixture
-def meshgrid(trajectory_gdf):
-    return create_meshgrid(
-        aoi=trajectory_gdf,
-        auto_scale_or_custom_cell_size=AutoScaleGridCellSize(),
-    )
 
 
 def test_set_patrol_weighting_spec():
@@ -186,88 +156,3 @@ def test_labeled_weighting_replaces_enum_with_labeled_options():
         {"const": "dist_meters", "title": "Distance"},
         {"const": "normalised_ltd", "title": "Normalised (LTD)"},
     ]
-
-
-@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters"])
-def test_classified_track_density_sum_matches_legacy_pipeline(trajectory_gdf, meshgrid, weighting):
-    spec = PATROL_WEIGHTING_SPECS[weighting]
-
-    result = calculate_classified_track_density(
-        geodataframe=trajectory_gdf,
-        meshgrid=meshgrid,
-        weighting_spec=spec,
-    )
-
-    legacy = calculate_feature_density(
-        geodataframe=trajectory_gdf,
-        meshgrid=meshgrid.copy(),
-        geometry_type="line",
-        sum_column=spec.density_sum_column,
-    )
-    legacy = normalize_density_units(df=legacy, weighting_spec=spec)
-    legacy = sort_values(df=legacy, column_name="density", ascending=True, na_position="last")
-    legacy = drop_nan_values_by_column(df=legacy, column_name="density")
-    legacy = apply_classification(
-        df=legacy,
-        input_column_name="density",
-        output_column_name="density_bins",
-        label_options=DefaultLabels(label_ranges=True, label_decimals=1),
-        classification_options=SharedArgs(scheme="equal_interval", k=10),
-    )
-
-    assert len(result) > 0
-    assert list(result["density"]) == list(legacy["density"])
-    assert list(result["density_bins"]) == list(legacy["density_bins"])
-    assert list(result.geometry) == list(legacy.geometry)
-
-
-def test_classified_track_density_ltd_matches_linear_time_density(trajectory_gdf, meshgrid):
-    result = calculate_classified_track_density(
-        geodataframe=trajectory_gdf,
-        meshgrid=meshgrid,
-        weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"],
-    )
-
-    expected = calculate_linear_time_density(
-        trajectory_gdf=trajectory_gdf,
-        meshgrid=meshgrid.copy(),
-    )
-
-    assert len(result) == len(expected)
-    assert list(result["density"]) == sorted(expected["percentile"])
-    assert list(result["density_bins"]) == [f"{p} %" for p in result["density"]]
-    expected_geoms = expected.sort_values("percentile").geometry
-    assert all(a.equals(b) for a, b in zip(result.geometry, expected_geoms))
-
-
-def test_classified_track_density_ltd_custom_percentiles(trajectory_gdf, meshgrid):
-    spec = set_patrol_weighting_spec(
-        weighting=PatrolWeightingSelection(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
-    )
-    result = calculate_classified_track_density(
-        geodataframe=trajectory_gdf,
-        meshgrid=meshgrid,
-        weighting_spec=spec,
-    )
-
-    expected = calculate_linear_time_density(
-        trajectory_gdf=trajectory_gdf,
-        meshgrid=meshgrid.copy(),
-        percentiles=[50.0, 90.0, 100.0],
-    )
-
-    assert set(result["density"]) <= {50.0, 90.0, 100.0}
-    assert len(result) == len(expected)
-    assert list(result["density"]) == sorted(expected["percentile"])
-
-
-@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters", "normalised_ltd"])
-def test_classified_track_density_empty_trajectory(trajectory_gdf, meshgrid, weighting):
-    result = calculate_classified_track_density(
-        geodataframe=trajectory_gdf.iloc[0:0],
-        meshgrid=meshgrid,
-        weighting_spec=PATROL_WEIGHTING_SPECS[weighting],
-    )
-    assert result.empty
-    assert "density" in result.columns
-    assert "density_bins" in result.columns

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -17,7 +17,10 @@ from ecoscope.platform.tasks.analysis import (
 )
 from ecoscope.platform.tasks.analysis._create_meshgrid import create_meshgrid
 from ecoscope.platform.tasks.analysis._density_weighting import labeled_weighting
-from ecoscope.platform.tasks.analysis._patrol_density import PATROL_WEIGHTING_SPECS
+from ecoscope.platform.tasks.analysis._patrol_density import (
+    PATROL_WEIGHTING_SPECS,
+    PatrolWeightingSelection,
+)
 from ecoscope.platform.tasks.analysis._time_density import AutoScaleGridCellSize
 from ecoscope.platform.tasks.transformation._classification import (
     DefaultLabels,
@@ -46,37 +49,38 @@ def meshgrid(trajectory_gdf):
 
 
 def test_set_patrol_weighting_spec():
-    assert (
-        set_patrol_weighting_spec(density_sum_column="timespan_seconds") is PATROL_WEIGHTING_SPECS["timespan_seconds"]
-    )
-    assert set_patrol_weighting_spec(density_sum_column="dist_meters") is PATROL_WEIGHTING_SPECS["dist_meters"]
-    assert set_patrol_weighting_spec(density_sum_column="normalised_ltd") is PATROL_WEIGHTING_SPECS["normalised_ltd"]
+    assert set_patrol_weighting_spec() is PATROL_WEIGHTING_SPECS["timespan_seconds"]
+    for choice in ("timespan_seconds", "dist_meters", "normalised_ltd"):
+        weighting = PatrolWeightingSelection(density_sum_column=choice)
+        assert set_patrol_weighting_spec(weighting=weighting) is PATROL_WEIGHTING_SPECS[choice]
 
 
-def test_reveal_ltd_config_only_for_ltd_schema_shape():
-    from wt_registry.jsonschema import jsonschema_from_task_func
-
-    from ecoscope.platform.tasks.analysis._patrol_density import _reveal_ltd_config_only_for_ltd
-
-    schema = jsonschema_from_task_func(set_patrol_weighting_spec)
-    if "allOf" not in schema:  # wt-registry without the task-level hook
-        _reveal_ltd_config_only_for_ltd(schema)
-
-    # base properties: only the dropdown; percentiles lives in the then-branch
+def test_weighting_selection_schema_shape():
+    # percentiles is hidden from base properties (SkipJsonSchema) and only
+    # revealed by the dependency branch for the Normalised (LTD) selection —
+    # the StatSummaryParam convert_units pattern.
+    schema = PatrolWeightingSelection.model_json_schema()
     assert list(schema["properties"]) == ["density_sum_column"]
     assert "additionalProperties" not in schema
-    (conditional,) = schema["allOf"]
-    assert conditional["if"]["properties"]["density_sum_column"]["const"] == "normalised_ltd"
-    percentiles = conditional["then"]["properties"]["percentiles"]
-    # lenient conditional-field shape: no default/minItems (RJSF seeds hidden
-    # arrays from first render; the task falls back to LTD defaults)
+    branches = schema["dependencies"]["density_sum_column"]["oneOf"]
+    ltd_branch = branches[-1]["properties"]
+    assert ltd_branch["density_sum_column"]["const"] == "normalised_ltd"
+    percentiles = ltd_branch["percentiles"]
+    # no default/minItems on a dependency-branch field: RJSF would seed the
+    # value into formData even while another option is selected
     assert "default" not in percentiles
     assert "minItems" not in percentiles
     assert percentiles["uniqueItems"] is True
 
 
+def test_weighting_selection_clears_orphaned_percentiles():
+    weighting = PatrolWeightingSelection(density_sum_column="timespan_seconds", percentiles=["50", "90"])
+    assert weighting.percentiles is None
+
+
 def test_set_patrol_weighting_spec_custom_percentiles():
-    spec = set_patrol_weighting_spec(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
+    weighting = PatrolWeightingSelection(density_sum_column="normalised_ltd", percentiles=["50", "90", "100"])
+    spec = set_patrol_weighting_spec(weighting=weighting)
     assert spec.percentiles == (50.0, 90.0, 100.0)
     assert spec.mode == "ltd"
     # the shared static spec stays untouched
@@ -206,7 +210,9 @@ def test_classified_track_density_ltd_matches_linear_time_density(trajectory_gdf
 
 
 def test_classified_track_density_ltd_custom_percentiles(trajectory_gdf, meshgrid):
-    spec = set_patrol_weighting_spec(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
+    spec = set_patrol_weighting_spec(
+        weighting=PatrolWeightingSelection(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
+    )
     result = calculate_classified_track_density(
         geodataframe=trajectory_gdf,
         meshgrid=meshgrid,

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -10,6 +10,7 @@ from ecoscope.platform.tasks.analysis import (
     calculate_classified_track_density,
     calculate_feature_density,
     calculate_linear_time_density,
+    get_density_colormap,
     get_density_legend_title,
     get_weighting_column,
     normalize_density_units,
@@ -107,7 +108,11 @@ def test_set_patrol_weighting_spec_custom_percentiles():
 def test_sum_specs_unchanged():
     time_spec = PATROL_WEIGHTING_SPECS["timespan_seconds"]
     assert isinstance(time_spec, SumWeightingSpec)
-    assert (time_spec.density_sum_column, time_spec.original_unit, time_spec.display_unit) == (
+    assert (
+        time_spec.density_sum_column,
+        time_spec.original_unit,
+        time_spec.display_unit,
+    ) == (
         "timespan_seconds",
         Unit.SECOND,
         Unit.HOUR,
@@ -115,7 +120,11 @@ def test_sum_specs_unchanged():
     assert time_spec.option_label == "Time"
     dist_spec = PATROL_WEIGHTING_SPECS["dist_meters"]
     assert isinstance(dist_spec, SumWeightingSpec)
-    assert (dist_spec.density_sum_column, dist_spec.original_unit, dist_spec.display_unit) == (
+    assert (
+        dist_spec.density_sum_column,
+        dist_spec.original_unit,
+        dist_spec.display_unit,
+    ) == (
         "dist_meters",
         Unit.METER,
         Unit.KILOMETER,
@@ -126,7 +135,10 @@ def test_sum_specs_unchanged():
 def test_ud_spec():
     ud_spec = PATROL_WEIGHTING_SPECS["normalised_ltd"]
     assert isinstance(ud_spec, UDWeightingSpec)
-    assert (ud_spec.option_label, ud_spec.legend_label) == ("Normalised (LTD)", "Time Spent")
+    assert (ud_spec.option_label, ud_spec.legend_label) == (
+        "Normalised (LTD)",
+        "Time Spent",
+    )
     assert ud_spec.display_unit == Unit.PERCENT
     assert ud_spec.percentiles is None
 
@@ -163,6 +175,14 @@ def test_get_density_legend_title():
     assert get_density_legend_title(weighting_spec=PATROL_WEIGHTING_SPECS["timespan_seconds"]) == "Time (h)"
     assert get_density_legend_title(weighting_spec=PATROL_WEIGHTING_SPECS["dist_meters"]) == "Distance (km)"
     assert get_density_legend_title(weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"]) == "Time Spent (%)"
+
+
+def test_get_density_colormap():
+    # Sum weightings: bins ascend, high sums red. UD: the lowest percentile
+    # isopleth is the densest core, so the direction flips.
+    assert get_density_colormap(weighting_spec=PATROL_WEIGHTING_SPECS["timespan_seconds"]) == "RdYlGn_r"
+    assert get_density_colormap(weighting_spec=PATROL_WEIGHTING_SPECS["dist_meters"]) == "RdYlGn_r"
+    assert get_density_colormap(weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"]) == "RdYlGn"
 
 
 def test_labeled_weighting_replaces_enum_with_labeled_options():

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -66,11 +66,24 @@ def test_weighting_selection_schema_shape():
     ltd_branch = branches[-1]["properties"]
     assert ltd_branch["density_sum_column"]["const"] == "normalised_ltd"
     percentiles = ltd_branch["percentiles"]
-    # pre-filled like the patrols workflow's Time Density Map; the seeded
-    # orphan for non-LTD selections is cleared by clear_orphaned_percentiles
-    assert percentiles["default"] == ["50", "60", "70", "80", "90", "100"]
+    # no default on the branch — RJSF never copies dependency-branch defaults
+    # into formData; the pre-fill rides on the param-level object default
+    assert "default" not in percentiles
     assert "minItems" not in percentiles
     assert percentiles["uniqueItems"] is True
+
+
+def test_weighting_param_default_seeds_ltd_percentiles():
+    from wt_registry.jsonschema import jsonschema_from_task_func
+
+    schema = jsonschema_from_task_func(set_patrol_weighting_spec)
+    # pre-filled like the patrols workflow's Time Density Map; while another
+    # option is selected the seeded value sits hidden in formData and
+    # clear_orphaned_percentiles discards it server-side
+    assert schema["properties"]["weighting"]["default"] == {
+        "density_sum_column": "timespan_seconds",
+        "percentiles": ["50", "60", "70", "80", "90", "100"],
+    }
 
 
 def test_weighting_selection_clears_orphaned_percentiles():

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -16,7 +16,11 @@ from ecoscope.platform.tasks.analysis import (
     set_patrol_weighting_spec,
 )
 from ecoscope.platform.tasks.analysis._create_meshgrid import create_meshgrid
-from ecoscope.platform.tasks.analysis._density_weighting import labeled_weighting
+from ecoscope.platform.tasks.analysis._density_weighting import (
+    SumWeightingSpec,
+    UDWeightingSpec,
+    labeled_weighting,
+)
 from ecoscope.platform.tasks.analysis._patrol_density import (
     PATROL_WEIGHTING_SPECS,
     PatrolWeightingSelection,
@@ -94,40 +98,42 @@ def test_weighting_selection_clears_orphaned_percentiles():
 def test_set_patrol_weighting_spec_custom_percentiles():
     weighting = PatrolWeightingSelection(density_sum_column="normalised_ltd", percentiles=["50", "90", "100"])
     spec = set_patrol_weighting_spec(weighting=weighting)
+    assert isinstance(spec, UDWeightingSpec)
     assert spec.percentiles == (50.0, 90.0, 100.0)
-    assert spec.mode == "ltd"
     # the shared static spec stays untouched
     assert PATROL_WEIGHTING_SPECS["normalised_ltd"].percentiles is None
 
 
 def test_sum_specs_unchanged():
     time_spec = PATROL_WEIGHTING_SPECS["timespan_seconds"]
+    assert isinstance(time_spec, SumWeightingSpec)
     assert (time_spec.density_sum_column, time_spec.original_unit, time_spec.display_unit) == (
         "timespan_seconds",
         Unit.SECOND,
         Unit.HOUR,
     )
-    assert (time_spec.option_label, time_spec.mode) == ("Time", "sum")
+    assert time_spec.option_label == "Time"
     dist_spec = PATROL_WEIGHTING_SPECS["dist_meters"]
+    assert isinstance(dist_spec, SumWeightingSpec)
     assert (dist_spec.density_sum_column, dist_spec.original_unit, dist_spec.display_unit) == (
         "dist_meters",
         Unit.METER,
         Unit.KILOMETER,
     )
-    assert (dist_spec.option_label, dist_spec.mode) == ("Distance", "sum")
+    assert dist_spec.option_label == "Distance"
 
 
-def test_ltd_spec():
-    ltd_spec = PATROL_WEIGHTING_SPECS["normalised_ltd"]
-    assert ltd_spec.density_sum_column == "timespan_seconds"
-    assert (ltd_spec.original_unit, ltd_spec.display_unit) == (Unit.SECOND, Unit.PERCENT)
-    assert (ltd_spec.option_label, ltd_spec.mode) == ("Normalised (LTD)", "ltd")
+def test_ud_spec():
+    ud_spec = PATROL_WEIGHTING_SPECS["normalised_ltd"]
+    assert isinstance(ud_spec, UDWeightingSpec)
+    assert (ud_spec.option_label, ud_spec.legend_label) == ("Normalised (LTD)", "Time Spent")
+    assert ud_spec.display_unit == Unit.PERCENT
+    assert ud_spec.percentiles is None
 
 
 def test_get_weighting_column():
     assert get_weighting_column(weighting_spec=PATROL_WEIGHTING_SPECS["timespan_seconds"]) == "timespan_seconds"
     assert get_weighting_column(weighting_spec=PATROL_WEIGHTING_SPECS["dist_meters"]) == "dist_meters"
-    assert get_weighting_column(weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"]) == "timespan_seconds"
 
 
 def test_normalize_density_units_time():

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -66,9 +66,9 @@ def test_weighting_selection_schema_shape():
     ltd_branch = branches[-1]["properties"]
     assert ltd_branch["density_sum_column"]["const"] == "normalised_ltd"
     percentiles = ltd_branch["percentiles"]
-    # no default/minItems on a dependency-branch field: RJSF would seed the
-    # value into formData even while another option is selected
-    assert "default" not in percentiles
+    # pre-filled like the patrols workflow's Time Density Map; the seeded
+    # orphan for non-LTD selections is cleared by clear_orphaned_percentiles
+    assert percentiles["default"] == ["50", "60", "70", "80", "90", "100"]
     assert "minItems" not in percentiles
     assert percentiles["uniqueItems"] is True
 

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -31,14 +31,13 @@ def test_set_patrol_weighting_spec():
 
 
 def test_weighting_selection_schema_shape():
-    # percentiles is only revealed by the Normalised (LTD) dependency branch
+    # percentiles is only revealed by the Normalised (LTD) conditional branch
     schema = PatrolWeightingSelection.model_json_schema()
     assert list(schema["properties"]) == ["density_sum_column"]
     assert "additionalProperties" not in schema
-    branches = schema["dependencies"]["density_sum_column"]["oneOf"]
-    ltd_branch = branches[-1]["properties"]
-    assert ltd_branch["density_sum_column"]["const"] == "normalised_ltd"
-    percentiles = ltd_branch["percentiles"]
+    (branch,) = schema["allOf"]
+    assert branch["if"]["properties"]["density_sum_column"]["const"] == "normalised_ltd"
+    percentiles = branch["then"]["properties"]["percentiles"]
     # no default on the branch — the pre-fill rides on the param-level default
     assert "default" not in percentiles
     assert "minItems" not in percentiles

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -53,6 +53,14 @@ def test_set_patrol_weighting_spec():
     assert set_patrol_weighting_spec(density_sum_column="normalised_ltd") is PATROL_WEIGHTING_SPECS["normalised_ltd"]
 
 
+def test_set_patrol_weighting_spec_custom_percentiles():
+    spec = set_patrol_weighting_spec(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
+    assert spec.percentiles == (50.0, 90.0, 100.0)
+    assert spec.mode == "ltd"
+    # the shared static spec stays untouched
+    assert PATROL_WEIGHTING_SPECS["normalised_ltd"].percentiles is None
+
+
 def test_sum_specs_unchanged():
     time_spec = PATROL_WEIGHTING_SPECS["timespan_seconds"]
     assert (time_spec.density_sum_column, time_spec.original_unit, time_spec.display_unit) == (
@@ -173,6 +181,25 @@ def test_classified_track_density_ltd_matches_linear_time_density(trajectory_gdf
     assert list(result["density_bins"]) == [f"{p} %" for p in result["density"]]
     expected_geoms = expected.sort_values("percentile").geometry
     assert all(a.equals(b) for a, b in zip(result.geometry, expected_geoms))
+
+
+def test_classified_track_density_ltd_custom_percentiles(trajectory_gdf, meshgrid):
+    spec = set_patrol_weighting_spec(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid,
+        weighting_spec=spec,
+    )
+
+    expected = calculate_linear_time_density(
+        trajectory_gdf=trajectory_gdf,
+        meshgrid=meshgrid.copy(),
+        percentiles=[50.0, 90.0, 100.0],
+    )
+
+    assert set(result["density"]) <= {50.0, 90.0, 100.0}
+    assert len(result) == len(expected)
+    assert list(result["density"]) == sorted(expected["percentile"])
 
 
 @pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters", "normalised_ltd"])

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -61,9 +61,7 @@ def test_set_patrol_weighting_spec():
 
 
 def test_weighting_selection_schema_shape():
-    # percentiles is hidden from base properties (SkipJsonSchema) and only
-    # revealed by the dependency branch for the Normalised (LTD) selection —
-    # the StatSummaryParam convert_units pattern.
+    # percentiles is only revealed by the Normalised (LTD) dependency branch
     schema = PatrolWeightingSelection.model_json_schema()
     assert list(schema["properties"]) == ["density_sum_column"]
     assert "additionalProperties" not in schema
@@ -71,8 +69,7 @@ def test_weighting_selection_schema_shape():
     ltd_branch = branches[-1]["properties"]
     assert ltd_branch["density_sum_column"]["const"] == "normalised_ltd"
     percentiles = ltd_branch["percentiles"]
-    # no default on the branch — RJSF never copies dependency-branch defaults
-    # into formData; the pre-fill rides on the param-level object default
+    # no default on the branch — the pre-fill rides on the param-level default
     assert "default" not in percentiles
     assert "minItems" not in percentiles
     assert percentiles["uniqueItems"] is True
@@ -82,9 +79,6 @@ def test_weighting_param_default_seeds_ltd_percentiles():
     from wt_registry.jsonschema import jsonschema_from_task_func
 
     schema = jsonschema_from_task_func(set_patrol_weighting_spec)
-    # pre-filled like the patrols workflow's Time Density Map; while another
-    # option is selected the seeded value sits hidden in formData and
-    # clear_orphaned_percentiles discards it server-side
     assert schema["properties"]["weighting"]["default"] == {
         "density_sum_column": "timespan_seconds",
         "percentiles": ["50", "60", "70", "80", "90", "100"],
@@ -178,8 +172,6 @@ def test_get_density_legend_title():
 
 
 def test_get_density_colormap():
-    # Sum weightings: bins ascend, high sums red. UD: the lowest percentile
-    # isopleth is the densest core, so the direction flips.
     assert get_density_colormap(weighting_spec=PATROL_WEIGHTING_SPECS["timespan_seconds"]) == "RdYlGn_r"
     assert get_density_colormap(weighting_spec=PATROL_WEIGHTING_SPECS["dist_meters"]) == "RdYlGn_r"
     assert get_density_colormap(weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"]) == "RdYlGn"

--- a/tests/platform/tasks/test_density_weighting.py
+++ b/tests/platform/tasks/test_density_weighting.py
@@ -53,6 +53,28 @@ def test_set_patrol_weighting_spec():
     assert set_patrol_weighting_spec(density_sum_column="normalised_ltd") is PATROL_WEIGHTING_SPECS["normalised_ltd"]
 
 
+def test_reveal_ltd_config_only_for_ltd_schema_shape():
+    from wt_registry.jsonschema import jsonschema_from_task_func
+
+    from ecoscope.platform.tasks.analysis._patrol_density import _reveal_ltd_config_only_for_ltd
+
+    schema = jsonschema_from_task_func(set_patrol_weighting_spec)
+    if "allOf" not in schema:  # wt-registry without the task-level hook
+        _reveal_ltd_config_only_for_ltd(schema)
+
+    # base properties: only the dropdown; percentiles lives in the then-branch
+    assert list(schema["properties"]) == ["density_sum_column"]
+    assert "additionalProperties" not in schema
+    (conditional,) = schema["allOf"]
+    assert conditional["if"]["properties"]["density_sum_column"]["const"] == "normalised_ltd"
+    percentiles = conditional["then"]["properties"]["percentiles"]
+    # lenient conditional-field shape: no default/minItems (RJSF seeds hidden
+    # arrays from first render; the task falls back to LTD defaults)
+    assert "default" not in percentiles
+    assert "minItems" not in percentiles
+    assert percentiles["uniqueItems"] is True
+
+
 def test_set_patrol_weighting_spec_custom_percentiles():
     spec = set_patrol_weighting_spec(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
     assert spec.percentiles == (50.0, 90.0, 100.0)

--- a/tests/platform/tasks/test_set_vars.py
+++ b/tests/platform/tasks/test_set_vars.py
@@ -1,0 +1,9 @@
+from ecoscope.platform.tasks.config import set_optional_string_var
+
+
+def test_set_optional_string_var_defaults_to_empty():
+    assert set_optional_string_var() == ""
+
+
+def test_set_optional_string_var_passthrough():
+    assert set_optional_string_var(var="Number of Animals") == "Number of Animals"

--- a/tests/platform/tasks/test_track_density.py
+++ b/tests/platform/tasks/test_track_density.py
@@ -1,0 +1,141 @@
+from importlib.resources import files
+
+import geopandas as gpd  # type: ignore[import-untyped]
+import pytest
+
+from ecoscope.platform.tasks.analysis import (
+    calculate_classified_track_density,
+    calculate_feature_density,
+    calculate_linear_time_density,
+    normalize_density_units,
+    set_patrol_weighting_spec,
+)
+from ecoscope.platform.tasks.analysis._create_meshgrid import create_meshgrid
+from ecoscope.platform.tasks.analysis._patrol_density import (
+    PATROL_WEIGHTING_SPECS,
+    PatrolWeightingSelection,
+)
+from ecoscope.platform.tasks.analysis._time_density import AutoScaleGridCellSize
+from ecoscope.platform.tasks.transformation._classification import (
+    DefaultLabels,
+    SharedArgs,
+    apply_classification,
+)
+from ecoscope.platform.tasks.transformation._filtering import drop_nan_values_by_column
+from ecoscope.platform.tasks.transformation._sorting import sort_values
+
+
+@pytest.fixture
+def trajectory_gdf():
+    example_input_df_path = (
+        files("ecoscope.platform.tasks.preprocessing") / "relocations-to-trajectory.example-return.parquet"
+    )
+    return gpd.read_parquet(example_input_df_path)
+
+
+@pytest.fixture
+def meshgrid(trajectory_gdf):
+    return create_meshgrid(
+        aoi=trajectory_gdf,
+        auto_scale_or_custom_cell_size=AutoScaleGridCellSize(),
+    )
+
+
+@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters"])
+def test_classified_track_density_sum_matches_legacy_pipeline(trajectory_gdf, meshgrid, weighting):
+    spec = PATROL_WEIGHTING_SPECS[weighting]
+
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid,
+        weighting_spec=spec,
+    )
+
+    legacy = calculate_feature_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid.copy(),
+        geometry_type="line",
+        sum_column=spec.density_sum_column,
+    )
+    legacy = normalize_density_units(df=legacy, weighting_spec=spec)
+    legacy = sort_values(df=legacy, column_name="density", ascending=True, na_position="last")
+    legacy = drop_nan_values_by_column(df=legacy, column_name="density")
+    legacy = apply_classification(
+        df=legacy,
+        input_column_name="density",
+        output_column_name="density_bins",
+        label_options=DefaultLabels(label_ranges=True, label_decimals=1),
+        classification_options=SharedArgs(scheme="equal_interval", k=10),
+    )
+
+    assert len(result) > 0
+    assert list(result["density"]) == list(legacy["density"])
+    assert list(result["density_bins"]) == list(legacy["density_bins"])
+    assert list(result.geometry) == list(legacy.geometry)
+
+
+def test_classified_track_density_ltd_matches_linear_time_density(trajectory_gdf, meshgrid):
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid,
+        weighting_spec=PATROL_WEIGHTING_SPECS["normalised_ltd"],
+    )
+
+    expected = calculate_linear_time_density(
+        trajectory_gdf=trajectory_gdf,
+        meshgrid=meshgrid.copy(),
+    )
+
+    assert len(result) == len(expected)
+    assert list(result["density"]) == sorted(expected["percentile"])
+    assert list(result["density_bins"]) == [f"{p} %" for p in result["density"]]
+    expected_geoms = expected.sort_values("percentile").geometry
+    assert all(a.equals(b) for a, b in zip(result.geometry, expected_geoms))
+
+
+def test_classified_track_density_ltd_custom_percentiles(trajectory_gdf, meshgrid):
+    spec = set_patrol_weighting_spec(
+        weighting=PatrolWeightingSelection(density_sum_column="normalised_ltd", percentiles=[50.0, 90.0, 100.0])
+    )
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=meshgrid,
+        weighting_spec=spec,
+    )
+
+    expected = calculate_linear_time_density(
+        trajectory_gdf=trajectory_gdf,
+        meshgrid=meshgrid.copy(),
+        percentiles=[50.0, 90.0, 100.0],
+    )
+
+    assert set(result["density"]) <= {50.0, 90.0, 100.0}
+    assert len(result) == len(expected)
+    assert list(result["density"]) == sorted(expected["percentile"])
+
+
+@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters", "normalised_ltd"])
+def test_classified_track_density_empty_trajectory(trajectory_gdf, meshgrid, weighting):
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf.iloc[0:0],
+        meshgrid=meshgrid,
+        weighting_spec=PATROL_WEIGHTING_SPECS[weighting],
+    )
+    assert result.empty
+    assert "density" in result.columns
+    assert "density_bins" in result.columns
+
+
+@pytest.mark.parametrize("weighting", ["timespan_seconds", "dist_meters", "normalised_ltd"])
+def test_classified_track_density_disjoint_grid(trajectory_gdf, meshgrid, weighting):
+    # a grid the trajectory never touches -> all-NaN densities -> empty result shape
+    disjoint = meshgrid.copy()
+    disjoint.geometry = disjoint.geometry.translate(xoff=1e6, yoff=1e6)
+    result = calculate_classified_track_density(
+        geodataframe=trajectory_gdf,
+        meshgrid=disjoint,
+        weighting_spec=PATROL_WEIGHTING_SPECS[weighting],
+    )
+    assert result.empty
+    assert "density" in result.columns
+    assert "density_bins" in result.columns


### PR DESCRIPTION
## Summary
- Add a third patrol density weighting option, **Normalised (LTD)**, to `set_patrol_weighting_spec`, reproducing the patrols workflow's Time Density Map (`calculate_ltd` → percentile classification → dissolve by percentile). Percentile levels are user-configurable: the picker is revealed only when Normalised (LTD) is selected (RJSF `dependencies` pattern) and comes pre-filled with the LTD defaults (patrols parity); orphaned percentiles left behind by switching modes are discarded server-side.
- New mode-aware composite task `calculate_classified_track_density(geodataframe, meshgrid, weighting_spec)` emits a uniform shape across modes — numeric `density` (hours/km for sum modes, percentile for UD) + ready-to-render `density_bins` labels (UD labels bake in the `" %"` suffix) — so one static spec pipeline can drive all three dropdown modes. The sum path is numerically identical to the existing `calculate_feature_density → normalize_density_units → sort_values → drop_nan_values_by_column → apply_classification` chain (tested).
- Split `WeightingSpec` into two frozen dataclasses under a union alias: `SumWeightingSpec` (sum column, original/display units, equal-interval bins) and `UDWeightingSpec` (percentiles, `%` display unit) — LTD is just the current UD algorithm, leaving room for others. Each carries a fixed `Literal` mode tag (`"sum"`/`"ud"`) as the union discriminator; dispatch is `isinstance`-based. `normalize_density_units` and `get_weighting_column` narrowed to `SumWeightingSpec`. The composite task and its branch helpers moved to a new `_track_density.py`, leaving `_density_weighting.py` as the spec layer (dataclasses + small spec-reading tasks).
- New `get_density_colormap` task: sum weightings use `RdYlGn_r` (high sums red); UD flips to `RdYlGn` since the lowest percentile isopleth is the densest core. The UD legend title is "Time Spent (%)"; `Unit.PERCENT` added as a display-only unit.
- `calculate_feature_density`'s sum mode made optional and robust; add `set_optional_string_var` config task.

Closes #787
