### PR TITLE
Create Parent Dirs for Nested Filenames in `_get_path`

### DIFF
--- a/ecoscope/platform/serde.py
+++ b/ecoscope/platform/serde.py
@@ -46,9 +46,8 @@ def _get_path(root_path: str, filename: str):
             else:
                 # Standard file URL or local path
                 local_path = Path(parsed_url.path)
-            if not local_path.exists():
-                local_path.mkdir(parents=True, exist_ok=True)
             write_path = local_path / filename
+            write_path.parent.mkdir(parents=True, exist_ok=True)
             read_path = write_path.absolute().as_posix()
 
         case "gs":

--- a/tests/platform/test_serde.py
+++ b/tests/platform/test_serde.py
@@ -60,3 +60,23 @@ def test_persist_bytes_failure_when_target_is_dir(tmp_path) -> None:
 def test_get_path_unsupported_scheme_raises() -> None:
     with pytest.raises(ValueError, match="Unsupported scheme"):
         _get_path("s3://bucket/path", "x.txt")
+
+
+def test_persist_text_nested_filename(tmp_path) -> None:
+    text = "<div>map</div>"
+    root_path = str(tmp_path / "out")
+    filename = "subdir/nested/map.html"
+    dst = _persist_text(text, root_path, filename)
+    with open(dst) as f:
+        assert f.read() == text
+    assert dst == os.path.join(root_path, filename)
+
+
+def test_persist_bytes_nested_filename(tmp_path) -> None:
+    data = b"binary-payload"
+    root_path = str(tmp_path / "out")
+    filename = "uuid/image_fileuploads/2026/7/28/uuid/photo.jpg"
+    dst = _persist_bytes(data, root_path, filename)
+    with open(dst, "rb") as f:
+        assert f.read() == data
+    assert dst == os.path.join(root_path, filename)


### PR DESCRIPTION
## :earth_americas: Summary
Attachments uploaded to Events from mobile phones return a filename that includes the full upload path (e.g. `uuid/image_fileuploads/2026/7/28/uuid/photo.jpg`) rather than a plain basename. `_get_path` only created local_path (the root dir), so when write_bytes was called on a nested path, it raised **FileNotFoundError**, causing `download_event_attachments` to fail.

## :package: Proposed Changes
Construct write_path first, then call `write_path.parent.mkdir(parents=True, exist_ok=True)` it handles both plain filenames and nested paths

Closes #791 