### PR TITLE
ERDW-247: Request subject `additional` from the DWH when needed

### DIFF
--- a/ecoscope/platform/schemas.py
+++ b/ecoscope/platform/schemas.py
@@ -127,6 +127,18 @@ class StrictSubjectGroupObservationsGDFSchema(RelocationsGDFSchema):
     extra__subject__name: pa_typing.Series[str] = pa.Field()
     extra__subject__subject_subtype: pa_typing.Series[str] = pa.Field()
     extra__subject__sex: pa_typing.Series[str] = pa.Field()
+    # The subject's free-form `additional` attributes. `Any` because the two backends
+    # disagree on shape: the EarthRanger API serves a dict, the warehouse a JSON string
+    # (see `assign_subject_colors`, which accepts either). Same reason `reported_by` is
+    # `Any` below.
+    #
+    # Optional and nullable rather than placeholder-filled like the columns above: the
+    # EarthRanger API always serves it, the warehouse serves it null unless the caller
+    # opts in, and consumers parse it -- so a "None" placeholder would be an unparsable
+    # value where null is already handled. `Series[...] | None` is what makes the column
+    # itself optional (pandera spells this `Optional[Series[...]]`; both resolve to
+    # `required=False`).
+    extra__subject__additional: pa_typing.Series[Any] | None = pa.Field(nullable=True)
 
 
 class StrictEventsGDFSchema(EventGDFSchema):

--- a/ecoscope/platform/schemas.py
+++ b/ecoscope/platform/schemas.py
@@ -127,18 +127,12 @@ class StrictSubjectGroupObservationsGDFSchema(RelocationsGDFSchema):
     extra__subject__name: pa_typing.Series[str] = pa.Field()
     extra__subject__subject_subtype: pa_typing.Series[str] = pa.Field()
     extra__subject__sex: pa_typing.Series[str] = pa.Field()
-    # The subject's free-form `additional` attributes. `Any` because the two backends
-    # disagree on shape: the EarthRanger API serves a dict, the warehouse a JSON string
-    # (see `assign_subject_colors`, which accepts either). Same reason `reported_by` is
-    # `Any` below.
-    #
-    # Optional and nullable rather than placeholder-filled like the columns above: the
-    # EarthRanger API always serves it, the warehouse serves it null unless the caller
-    # opts in, and consumers parse it -- so a "None" placeholder would be an unparsable
-    # value where null is already handled. `Series[...] | None` is what makes the column
-    # itself optional (pandera spells this `Optional[Series[...]]`; both resolve to
-    # `required=False`).
+    # Free-form subject attributes: dict from the ER API, JSON string from the warehouse, null when not requested.
     extra__subject__additional: pa_typing.Series[Any] | None = pa.Field(nullable=True)
+
+    @pa.check("extra__subject__additional", name="str_or_dict")
+    def check_additional_is_str_or_dict(cls, series: pd.Series) -> pd.Series:  # type: ignore[misc]
+        return series.map(lambda value: isinstance(value, (str, dict)))
 
 
 class StrictEventsGDFSchema(EventGDFSchema):

--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -481,8 +481,23 @@ def get_subjectgroup_observations(
             description="Filter observations based on exclusion flags.",
         ),
     ] = "clean",
+    include_subject_additional: Annotated[
+        bool,
+        AdvancedField(
+            default=False,
+            title="Include Subject Additional",
+            description="Whether or not to include the subject's free-form `additional` JSON",
+        ),
+    ] = False,
 ) -> SubjectGroupObservationsGDF | EmptyDataFrame:
-    """Get observations for a subject group from EarthRanger."""
+    """Get observations for a subject group from EarthRanger.
+
+    ``include_subject_additional`` only affects the warehouse path. The EarthRanger API
+    path serves the subject's ``additional`` JSON unconditionally (it rides along with
+    ``include_subject_details``), whereas the warehouse serves the column null unless
+    asked, so consumers of ``subject__additional`` -- e.g. ``assign_subject_colors``,
+    which reads its ``rgb`` key -- must opt in to get the same data from both backends.
+    """
     from ecoscope.relocations import Relocations
 
     filter_int = _EXCLUSION_FILTER_TO_INT[filter]
@@ -502,6 +517,7 @@ def get_subjectgroup_observations(
             since=time_range.since.isoformat(),
             until=time_range.until.isoformat(),
             filter=filter_int,
+            include_subject_additional=include_subject_additional,
         )
         subject_group_obs_relocs = _sort_warehouse_relocations(gpd.GeoDataFrame.from_arrow(table))
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.21",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.22",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",

--- a/tests/platform/tasks/conftest.py
+++ b/tests/platform/tasks/conftest.py
@@ -1,0 +1,56 @@
+"""Shared fixtures for the platform task tests.
+
+The warehouse observations table factory lives here rather than in the individual
+warehouse test modules: it is built against ``OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1``,
+and ``pa.table(..., schema=...)`` raises ``KeyError`` for any schema field it is not
+given an array for. So every column io-core adds to that schema breaks every copy of
+this helper at once -- which is exactly what happened when v0.0.22 added
+``subject_additional``.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.fixture
+def warehouse_observations_table():
+    """Callable building a ``pa.Table`` shaped like ``ERWarehouseClient`` observations.
+
+    ``fixtimes`` are emitted in the order given, which is what lets callers simulate the
+    warehouse returning rows in an arbitrary order; omit them for one fix per subject a
+    minute apart. ``additional`` is one value per row for ``extra__subject__additional``
+    -- pass None for an all-null column, which is what the warehouse serves when the
+    caller does not set ``include_subject_additional``.
+    """
+
+    def _make(subject_ids=("s1", "s2"), fixtimes=None, sources=None, additional=None):
+        import geoarrow.pyarrow as ga  # type: ignore[import-untyped]
+        import pyarrow as pa
+        from ecoscope_earthranger_io_core.arrow import OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1
+        from shapely.geometry import Point
+
+        subject_ids = list(subject_ids)
+        n = len(subject_ids)
+        if fixtimes is None:
+            fixtimes = [datetime(2015, 1, 1, minute=i, tzinfo=timezone.utc) for i in range(n)]
+        if sources is None:
+            sources = [f"source-{s}" for s in subject_ids]
+
+        return pa.table(
+            {
+                "geometry": ga.array([Point(37.5 + i * 0.001, -2.5).wkb for i in range(n)]),
+                "fixtime": pa.array(list(fixtimes), type=pa.timestamp("ns", tz="UTC")),
+                "groupby_col": pa.array(subject_ids, type=pa.string()),
+                "extra__subject__name": pa.array([f"subj-{s}" for s in subject_ids], type=pa.string()),
+                "extra__subject__subject_subtype": pa.array(["elephant"] * n, type=pa.string()),
+                "extra__subject__additional": pa.array(
+                    list(additional) if additional is not None else [None] * n, type=pa.string()
+                ),
+                "extra__source": pa.array(list(sources), type=pa.string()),
+                "junk_status": pa.array([False] * n, type=pa.bool_()),
+            },
+            schema=OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1,
+        )
+
+    return _make

--- a/tests/platform/tasks/test_earthranger_schemas.py
+++ b/tests/platform/tasks/test_earthranger_schemas.py
@@ -37,7 +37,10 @@ def test_subjectgroupobservations_schema():
         "extra__subject__subject_subtype",
         "extra__subject__sex",
     ]
-    assert [col in result for col in allowed_missing_columns]
+    assert all(col in result for col in allowed_missing_columns)
+    # `extra__subject__additional` is optional too, but is deliberately not placeholder-
+    # injected: consumers parse it, and "None" is not parseable.
+    assert "extra__subject__additional" not in result
     assert result.extra__subject__name.to_list() == ["Test", "None"]
     assert result.extra__subject__subject_subtype.to_list() == ["None", "None"]
     assert result.extra__subject__sex.to_list() == ["None", "None"]

--- a/tests/platform/tasks/test_io_earthranger_warehouse_sort.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_sort.py
@@ -29,35 +29,6 @@ _TIME_RANGE = TimeRange(
 )
 
 
-def _make_observations_arrow_table(fixtimes, subject_ids, sources=None):
-    """Build a pa.Table matching OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1.
-
-    ``fixtimes`` are emitted in the given order, which is what lets these tests
-    simulate the warehouse returning rows in an arbitrary order.
-    """
-    import geoarrow.pyarrow as ga  # type: ignore[import-untyped]
-    import pyarrow as pa
-    from ecoscope_earthranger_io_core.arrow import OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1
-    from shapely.geometry import Point
-
-    n = len(fixtimes)
-    sources = sources if sources is not None else ["source-1"] * n
-    geometries = [Point(37.5 + i * 0.001, -2.5).wkb for i in range(n)]
-
-    return pa.table(
-        {
-            "geometry": ga.array(geometries),
-            "fixtime": pa.array(fixtimes, type=pa.timestamp("ns", tz="UTC")),
-            "groupby_col": pa.array(subject_ids, type=pa.string()),
-            "extra__subject__name": pa.array([f"subj-{s}" for s in subject_ids], type=pa.string()),
-            "extra__subject__subject_subtype": pa.array(["elephant"] * n, type=pa.string()),
-            "extra__source": pa.array(sources, type=pa.string()),
-            "junk_status": pa.array([False] * n, type=pa.bool_()),
-        },
-        schema=OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1,
-    )
-
-
 def _fixtimes(minutes):
     return [datetime(2015, 1, 1, tzinfo=timezone.utc).replace(minute=m % 60, hour=m // 60) for m in minutes]
 
@@ -140,11 +111,11 @@ class TestGetSubjectgroupObservationsRowOrder:
         mock_legacy_client.get_subjectgroup_observations.assert_not_called()
         return result
 
-    def test_unordered_warehouse_rows_are_sorted(self):
+    def test_unordered_warehouse_rows_are_sorted(self, warehouse_observations_table):
         """Rows arriving in arbitrary order come back time-ordered per subject."""
-        table = _make_observations_arrow_table(
-            fixtimes=_fixtimes([50, 10, 30, 20, 40]),
+        table = warehouse_observations_table(
             subject_ids=["s1", "s2", "s1", "s1", "s2"],
+            fixtimes=_fixtimes([50, 10, 30, 20, 40]),
         )
         result = self._call_with_table(table)
 
@@ -152,12 +123,14 @@ class TestGetSubjectgroupObservationsRowOrder:
         assert len(result) == 5
         assert result.groupby("groupby_col")["fixtime"].is_monotonic_increasing.all()
 
-    def test_row_order_does_not_change_content(self):
+    def test_row_order_does_not_change_content(self, warehouse_observations_table):
         """Sorting must reorder rows only -- never add, drop, or alter them."""
         ordered = _fixtimes([10, 20, 30, 40, 50])
         subjects = ["s1"] * 5
-        forward = self._call_with_table(_make_observations_arrow_table(ordered, subjects))
-        reversed_ = self._call_with_table(_make_observations_arrow_table(list(reversed(ordered)), subjects))
+        forward = self._call_with_table(warehouse_observations_table(subject_ids=subjects, fixtimes=ordered))
+        reversed_ = self._call_with_table(
+            warehouse_observations_table(subject_ids=subjects, fixtimes=list(reversed(ordered)))
+        )
 
         assert list(forward.fixtime) == list(reversed_.fixtime)
         assert len(forward) == len(reversed_) == 5

--- a/tests/platform/tasks/test_io_earthranger_warehouse_subject_additional.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_subject_additional.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import geopandas as gpd  # type: ignore[import-untyped]
 import pandas as pd
 import pytest
+from pandera.errors import SchemaError
 from pydantic import TypeAdapter
 from shapely.geometry import Point
 
@@ -172,6 +173,27 @@ class TestAdditionalColumnInResult:
         validated = _RETURN_TYPE.validate_python(gdf)
 
         assert validated.extra__subject__additional.iloc[0] == {"rgb": "255, 0, 0"}
+
+    @pytest.mark.parametrize("value", [pytest.param(5, id="int"), pytest.param(["255, 0, 0"], id="list")])
+    def test_shapes_neither_backend_serves_are_rejected(self, value):
+        """`Any` is the dtype because pandera has no str-or-dict union, but the column is
+        still narrowed to the two shapes a backend can actually produce."""
+        gdf = gpd.GeoDataFrame(
+            {
+                "geometry": [Point(0, 0)],
+                "groupby_col": ["s1"],
+                "fixtime": pd.to_datetime(["2015-01-01"], utc=True),
+                "junk_status": [False],
+                "extra__subject__name": ["subj-s1"],
+                "extra__subject__subject_subtype": ["elephant"],
+                "extra__subject__sex": ["female"],
+                "extra__subject__additional": [value],
+            },
+            crs=4326,
+        )
+
+        with pytest.raises(SchemaError, match="str_or_dict"):
+            _RETURN_TYPE.validate_python(gdf)
 
 
 class TestColoringParity:

--- a/tests/platform/tasks/test_io_earthranger_warehouse_subject_additional.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_subject_additional.py
@@ -1,0 +1,251 @@
+"""Unit tests for the subject ``additional`` opt-in on the ERWarehouseClient
+observations path (ERDW-247; consumes the warehouse-side flag added in ERDW-266).
+
+The EarthRanger API path serves the subject's ``additional`` JSON unconditionally, as
+part of ``include_subject_details``. The warehouse serves the column but leaves it null
+unless the query asks for it, so a consumer that reads ``additional`` -- e.g.
+``assign_subject_colors``, which colors tracks from its ``rgb`` key -- gets different
+results from the two backends unless the task opts in. These tests pin the flag's
+forwarding and the resulting cross-backend parity.
+
+They use a mocked ERWarehouseClient (no live server), so unlike the integration tests in
+test_io_earthranger.py they are NOT marked ``io`` and run in the default test job.
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import geopandas as gpd  # type: ignore[import-untyped]
+import pandas as pd
+import pytest
+from pydantic import TypeAdapter
+from shapely.geometry import Point
+
+from ecoscope.platform.annotations import EmptyDataFrame
+from ecoscope.platform.schemas import SubjectGroupObservationsGDF
+from ecoscope.platform.tasks.filter._filter import UTC_TIMEZONEINFO, TimeRange
+from ecoscope.platform.tasks.io import get_subjectgroup_observations
+from ecoscope.platform.tasks.transformation import assign_subject_colors, drop_column_prefix
+
+# The task's declared return type, validated in production: wt_task wraps every task in
+# `validate_call(..., validate_return=True)`. Asserting through this rather than through
+# `StrictSubjectGroupObservationsGDFSchema` directly also exercises the AfterValidators
+# that inject the other optional columns.
+_RETURN_TYPE = TypeAdapter(SubjectGroupObservationsGDF | EmptyDataFrame)
+
+_TIME_RANGE = TimeRange(
+    since=datetime(2015, 1, 1, tzinfo=timezone.utc),
+    until=datetime(2015, 1, 31, tzinfo=timezone.utc),
+    timezone=UTC_TIMEZONEINFO,
+)
+
+# The format EarthRanger stores in `additional`: comma-separated decimal channels, not
+# hex (see `parse_rgb_str` in tasks/transformation/_subjects.py).
+_RED = json.dumps({"rgb": "255, 0, 0", "sex": "female", "region": "Gourma"})
+_BLUE = json.dumps({"rgb": "0, 0, 255", "sex": "male", "region": "Gourma"})
+
+
+def _call_via_warehouse(table, **task_kwargs):
+    """Run the task against a mocked warehouse client; return (result, call kwargs)."""
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_subjectgroup_observations.return_value = table
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        result = get_subjectgroup_observations(
+            client=MagicMock(),
+            time_range=_TIME_RANGE,
+            subject_group_name="Ecoscope-5-Subs",
+            raise_on_empty=False,
+            **task_kwargs,
+        )
+
+    return result, mock_warehouse_client.get_subjectgroup_observations.call_args.kwargs
+
+
+class TestFlagForwarding:
+    def test_defaults_to_not_requesting(self, warehouse_observations_table):
+        """Opt-in: workflows that never read `additional` must not pay for it."""
+        _, call_kwargs = _call_via_warehouse(warehouse_observations_table())
+
+        assert call_kwargs["include_subject_additional"] is False
+
+    def test_forwarded_when_requested(self, warehouse_observations_table):
+        _, call_kwargs = _call_via_warehouse(
+            warehouse_observations_table(additional=[_RED, _BLUE]),
+            include_subject_additional=True,
+        )
+
+        assert call_kwargs["include_subject_additional"] is True
+
+    @pytest.mark.parametrize("requested", [False, True])
+    def test_not_forwarded_to_earthranger_api_client(self, requested):
+        """The legacy client has no such kwarg -- forwarding it would be a TypeError.
+
+        The EarthRanger API serves `additional` unconditionally, so there is nothing to
+        request on that path.
+        """
+        mock_legacy_client = MagicMock()
+        mock_legacy_client.get_subjectgroup_observations.return_value = gpd.GeoDataFrame()
+
+        with patch(
+            "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+            return_value=None,
+        ):
+            get_subjectgroup_observations(
+                client=mock_legacy_client,
+                time_range=_TIME_RANGE,
+                subject_group_name="Ecoscope-5-Subs",
+                raise_on_empty=False,
+                include_subject_additional=requested,
+            )
+
+        call_kwargs = mock_legacy_client.get_subjectgroup_observations.call_args.kwargs
+        assert "include_subject_additional" not in call_kwargs
+
+
+class TestAdditionalColumnInResult:
+    def test_json_reaches_the_dataframe(self, warehouse_observations_table):
+        result, _ = _call_via_warehouse(
+            warehouse_observations_table(additional=[_RED, _BLUE]),
+            include_subject_additional=True,
+        )
+
+        assert json.loads(result.extra__subject__additional.iloc[0])["rgb"] == "255, 0, 0"
+        assert json.loads(result.extra__subject__additional.iloc[1])["rgb"] == "0, 0, 255"
+
+    def test_column_present_but_null_when_not_requested(self, warehouse_observations_table):
+        """Null rather than absent: downstream column lookups stay stable either way."""
+        result, _ = _call_via_warehouse(warehouse_observations_table())
+
+        assert "extra__subject__additional" in result.columns
+        assert result.extra__subject__additional.isna().all()
+
+    @pytest.mark.parametrize(
+        "additional",
+        [
+            pytest.param(None, id="all-null"),
+            pytest.param([_RED, _BLUE], id="json"),
+            pytest.param([_RED, None], id="mixed"),
+            pytest.param(["{}", "{}"], id="empty-json"),
+        ],
+    )
+    def test_result_satisfies_the_subject_group_schema(self, warehouse_observations_table, additional):
+        """`extra__subject__additional` is declared optional and nullable, so each of
+        the values the warehouse can serve -- null, '{}' or JSON -- validates."""
+        result, _ = _call_via_warehouse(warehouse_observations_table(additional=additional))
+
+        validated = _RETURN_TYPE.validate_python(result)
+
+        # Nulls must survive validation as nulls. The column is deliberately left out of
+        # `_subject_group_obs_optional_columns`, whose `fillna` would turn them into the
+        # string "None" -- unparsable JSON, where null is already handled.
+        if additional is None:
+            assert validated.extra__subject__additional.isna().all()
+
+    def test_earthranger_api_dict_additional_satisfies_the_schema(self):
+        """The EarthRanger API serves `additional` as a dict, the warehouse as a JSON
+        string, so the column cannot be typed `str`.
+
+        `ecoscope/io/earthranger.py` reads it as a dict (`df["additional"].str["rgb"]`,
+        and `pack_columns` splats it with `{**add_dict}`), and `assign_subject_colors`
+        has an explicit `isinstance(additional_data, dict)` branch for it. Typing the
+        column `str` would abort every subject-group workflow on a non-warehouse site.
+        """
+        gdf = gpd.GeoDataFrame(
+            {
+                "geometry": [Point(0, 0), Point(1, 1)],
+                "groupby_col": ["s1", "s2"],
+                "fixtime": pd.to_datetime(["2015-01-01", "2015-01-02"], utc=True),
+                "junk_status": [False, False],
+                "extra__subject__name": ["subj-s1", "subj-s2"],
+                "extra__subject__subject_subtype": ["elephant"] * 2,
+                "extra__subject__sex": ["female", "male"],
+                "extra__subject__additional": [{"rgb": "255, 0, 0"}, {}],
+            },
+            crs=4326,
+        )
+
+        validated = _RETURN_TYPE.validate_python(gdf)
+
+        assert validated.extra__subject__additional.iloc[0] == {"rgb": "255, 0, 0"}
+
+
+class TestColoringParity:
+    """The reason the flag exists: `assign_subject_colors` reading `rgb`.
+
+    Mirrors the download-subject-tracks node chain -- warehouse observations, then
+    `drop_column_prefix("extra__")`, then `assign_subject_colors` keyed on
+    `groupby_col`.
+    """
+
+    def _colors(self, table, **task_kwargs):
+        result, _ = _call_via_warehouse(table, **task_kwargs)
+        result = drop_column_prefix(df=result, prefix="extra__")
+        colored = assign_subject_colors(
+            df=result,
+            subject_id_column="groupby_col",
+            additional_column="subject__additional",
+            output_column="subject_colormap",
+            fallback_strategy="default_color",
+            default_color="#FFFF00",
+        )
+        return dict(zip(colored.groupby_col, colored.subject_colormap))
+
+    def test_requested_additional_yields_each_subjects_own_color(self, warehouse_observations_table):
+        colors = self._colors(
+            warehouse_observations_table(additional=[_RED, _BLUE]),
+            include_subject_additional=True,
+        )
+
+        assert colors["s1"] == (255, 0, 0, 255)
+        assert colors["s2"] == (0, 0, 255, 255)
+
+    @pytest.mark.parametrize(
+        "additional",
+        [
+            pytest.param(None, id="not-requested-null"),
+            pytest.param(["{}", "{}"], id="requested-no-attributes"),
+        ],
+    )
+    def test_additional_without_rgb_falls_back_without_raising(self, warehouse_observations_table, additional):
+        """Both no-rgb states must degrade to the default color, not crash: other
+        workflows share this task and never opt in."""
+        colors = self._colors(warehouse_observations_table(additional=additional))
+
+        assert set(colors.values()) == {(255, 255, 0, 255)}
+
+    def test_earthranger_api_dict_additional_yields_the_same_colors(self, warehouse_observations_table):
+        """Cross-backend parity, which is the point of the flag: the ER API's dict and
+        the warehouse's JSON string must color identically."""
+        table = warehouse_observations_table(additional=[_RED, _BLUE])
+        warehouse_colors = self._colors(table, include_subject_additional=True)
+
+        er_api_frame = drop_column_prefix(
+            df=gpd.GeoDataFrame(
+                {
+                    "groupby_col": ["s1", "s2"],
+                    "extra__subject__additional": [json.loads(_RED), json.loads(_BLUE)],
+                    "geometry": [Point(0, 0), Point(1, 1)],
+                }
+            ),
+            prefix="extra__",
+        )
+        er_api_colors = dict(
+            zip(
+                er_api_frame.groupby_col,
+                assign_subject_colors(
+                    df=er_api_frame,
+                    subject_id_column="groupby_col",
+                    additional_column="subject__additional",
+                    output_column="subject_colormap",
+                    fallback_strategy="default_color",
+                    default_color="#FFFF00",
+                ).subject_colormap,
+            )
+        )
+
+        assert er_api_colors == warehouse_colors == {"s1": (255, 0, 0, 255), "s2": (0, 0, 255, 255)}


### PR DESCRIPTION
## :earth_americas: Summary
Closes #800 
## :package: Proposed Changes
- Adds an opt-in `include_subject_additional` param to the `get_subjectgroup_observations` task, forwarded only on the warehouse path (the  EarthRanger API already serves the field unconditionally), and bumps the io-core pin to `v0.0.22 `where the flag exists.
- Also declares `extra__subject__additional` on the subject-group schema as optional and nullable.

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary