### PR TITLE
Allow `gather_dashboard` to accept a list of file paths

### DIFF
--- a/ecoscope/platform/tasks/results/__init__.py
+++ b/ecoscope/platform/tasks/results/__init__.py
@@ -35,7 +35,7 @@ from ._pydeck import (
 )
 from ._table import draw_table
 from ._widget_tasks import (
-    create_files_list_single_view,
+    create_files_single_view,
     create_map_v2_widget_single_view,
     create_map_widget_single_view,
     create_plot_widget_single_view,
@@ -72,7 +72,7 @@ __all__ = [
     "create_single_value_widget_single_view",
     "create_table_widget_single_view",
     "create_text_widget_single_view",
-    "create_files_list_single_view",
+    "create_files_single_view",
     "merge_widget_views",
     "merge_file_views",
     "create_geojson_layer",

--- a/ecoscope/platform/tasks/results/__init__.py
+++ b/ecoscope/platform/tasks/results/__init__.py
@@ -35,12 +35,14 @@ from ._pydeck import (
 )
 from ._table import draw_table
 from ._widget_tasks import (
+    create_files_list_single_view,
     create_map_v2_widget_single_view,
     create_map_widget_single_view,
     create_plot_widget_single_view,
     create_single_value_widget_single_view,
     create_table_widget_single_view,
     create_text_widget_single_view,
+    merge_file_views,
     merge_widget_views,
 )
 
@@ -70,7 +72,9 @@ __all__ = [
     "create_single_value_widget_single_view",
     "create_table_widget_single_view",
     "create_text_widget_single_view",
+    "create_files_list_single_view",
     "merge_widget_views",
+    "merge_file_views",
     "create_geojson_layer",
     "create_hexagon_layer",
     "create_icon_layer",

--- a/ecoscope/platform/tasks/results/_dashboard.py
+++ b/ecoscope/platform/tasks/results/_dashboard.py
@@ -93,17 +93,27 @@ class DashboardFile(BaseModel):
 
 
 class DashboardView(BaseModel):
-    """The contents of a single dashboard view: its widgets and associated files."""
+    """The contents of a single dashboard view: its widgets and associated files.
+
+    This wrapper is only used when a dashboard actually has associated files. When a
+    dashboard has no files, each view is serialized as a bare list of widgets (see
+    `Dashboard._iter_views_json`) to preserve the historical output shape.
+    """
 
     dashboard: list[EmumeratedWidgetSingleView]
     files: list[DashboardFile]
+
+
+# A view is serialized either as the file-aware `DashboardView` (when the dashboard has
+# files) or as a bare list of widgets (the historical shape, when it has none).
+SerializedView = DashboardView | list[EmumeratedWidgetSingleView]
 
 
 class DashboardJson(BaseModel):
     """A JSON-serialized representation of a dashboard."""
 
     filters: dict | None
-    views: dict[str, DashboardView]
+    views: dict[str, SerializedView]
     metadata: Metadata
     layout: list  # this is a placeholder for future use by server
 
@@ -174,28 +184,36 @@ class Dashboard(BaseModel):
             paths += self.files.get_view(view)
         return [DashboardFile(path=p) for p in paths]
 
+    def _view_value(self, view: CompositeFilter | None) -> SerializedView:
+        """Build the serialized value for a single view. If the dashboard has associated
+        files, wrap the widgets and files in a `DashboardView`. Otherwise, yield a bare
+        list of widgets, preserving the historical (file-free) output shape.
+        """
+        widgets = self._get_view(view)
+        if self.files is None:
+            return widgets
+        return DashboardView(dashboard=widgets, files=self._get_files(view))
+
     def _iter_views_json(
         self,
-    ) -> Generator[tuple[str, DashboardView], None, None]:
+    ) -> Generator[tuple[str, SerializedView], None, None]:
         """Iterate over all possible views for the dashboard, yielding key:value pairs for each,
         in which the keys are a JSON-stringified representation of the views key, and the values
-        are JSON-serializable `DashboardView`s containing the widgets and associated files.
+        are JSON-serializable views. When the dashboard has associated files, each value is a
+        `DashboardView` wrapping the widgets and files; otherwise it is a bare list of widgets.
         """
         if not self.keys:
             # if there is no grouping for any widgets, there is only one view
             # so yield it back as a single view with an empty key
-            yield json.dumps({}), DashboardView(dashboard=self._get_view(None), files=self._get_files(None))
+            yield json.dumps({}), self._view_value(None)
             # and then stop iterating
             return
         for k in self.keys:
             asdict = {attr: value for attr, _, value in k}
-            yield (
-                json.dumps(asdict, sort_keys=True),
-                DashboardView(dashboard=self._get_view(k), files=self._get_files(k)),
-            )
+            yield json.dumps(asdict, sort_keys=True), self._view_value(k)
 
     @property
-    def views_json(self) -> dict[str, DashboardView]:
+    def views_json(self) -> dict[str, SerializedView]:
         """A JSON-serializable dictionary for all possible views of the dashboard,
         keyed by JSON-stringified representations of the views keys.
         """
@@ -405,6 +423,15 @@ def gather_dashboard(
         grouped_files = GroupedFiles(views={})
         for f in as_flat_files:
             grouped_files |= GroupedFiles.from_single_view(f) if isinstance(f, FilesListSingleView) else f
+        # a `None` file key is ungrouped/global and applies to every view; any other file key
+        # must correspond to a dashboard view key, otherwise those files would be silently
+        # dropped at serialization time (mirrors the grouped-widget key check above).
+        valid_view_keys = all_view_keys if groupers else set()
+        file_view_keys = {k for k in grouped_files.views if k is not None}
+        assert file_view_keys <= valid_view_keys, (
+            f"File view keys must be ungrouped (`None`) or match the dashboard's view keys. "
+            f"Unexpected file view keys: {file_view_keys - valid_view_keys}"
+        )
 
     return Dashboard(
         widgets=grouped_widgets,

--- a/ecoscope/platform/tasks/results/_dashboard.py
+++ b/ecoscope/platform/tasks/results/_dashboard.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Annotated, Any, Generator
 
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
@@ -25,6 +26,8 @@ from ecoscope.platform.jsonschema import (
 from ecoscope.platform.tasks.config._workflow_details import WorkflowDetails
 from ecoscope.platform.tasks.filter._filter import TimeRange
 from ecoscope.platform.tasks.results._widget_types import (
+    FilesListSingleView,
+    GroupedFiles,
     GroupedWidget,
     WidgetBase,
     WidgetData,
@@ -83,11 +86,24 @@ class Metadata(BaseModel):
         return all_fields
 
 
+class DashboardFile(BaseModel):
+    """A file associated with a dashboard view."""
+
+    path: Path
+
+
+class DashboardView(BaseModel):
+    """The contents of a single dashboard view: its widgets and associated files."""
+
+    dashboard: list[EmumeratedWidgetSingleView]
+    files: list[DashboardFile]
+
+
 class DashboardJson(BaseModel):
     """A JSON-serialized representation of a dashboard."""
 
     filters: dict | None
-    views: dict[str, list[EmumeratedWidgetSingleView]]
+    views: dict[str, DashboardView]
     metadata: Metadata
     layout: list  # this is a placeholder for future use by server
 
@@ -102,6 +118,8 @@ class Dashboard(BaseModel):
             If all widgets are ungrouped, this field is `None`.
         keys: A list of composite filters that represent the possible views for the grouped widgets.
             If all widgets are ungrouped, this field is `None`.
+        files: Files associated with the dashboard, grouped by view. If there are no
+            associated files, this field is `None`.
         metadata: Descriptive metadata for the dashboard.
     """
 
@@ -114,6 +132,7 @@ class Dashboard(BaseModel):
         | None
     ) = None
     keys: list[CompositeFilter] | None = None
+    files: GroupedFiles | None = None
     metadata: Metadata = Field(default_factory=Metadata)
 
     def _get_view(self, view: CompositeFilter | None) -> list[EmumeratedWidgetSingleView]:
@@ -140,25 +159,37 @@ class Dashboard(BaseModel):
             for i, w in enumerate(self.widgets)
         ]
 
+    def _get_files(self, view: CompositeFilter | None) -> list[DashboardFile]:
+        """Get the files associated with a view. If the dashboard's files are ungrouped
+        (i.e. only have a `None` key), request `None` for that view, mirroring `_get_view`.
+        """
+        if self.files is None:
+            return []
+        key = view if list(self.files.views) != [None] else None
+        return [DashboardFile(path=p) for p in self.files.get_view(key)]
+
     def _iter_views_json(
         self,
-    ) -> Generator[tuple[str, list[EmumeratedWidgetSingleView]], None, None]:
+    ) -> Generator[tuple[str, DashboardView], None, None]:
         """Iterate over all possible views for the dashboard, yielding key:value pairs for each,
         in which the keys are a JSON-stringified representation of the views key, and the values
-        are JSON-serializable dictionaries of the widget view.
+        are JSON-serializable `DashboardView`s containing the widgets and associated files.
         """
         if not self.keys:
             # if there is no grouping for any widgets, there is only one view
             # so yield it back as a single view with an empty key
-            yield json.dumps({}), self._get_view(None)
+            yield json.dumps({}), DashboardView(dashboard=self._get_view(None), files=self._get_files(None))
             # and then stop iterating
             return
         for k in self.keys:
             asdict = {attr: value for attr, _, value in k}
-            yield json.dumps(asdict, sort_keys=True), self._get_view(k)
+            yield (
+                json.dumps(asdict, sort_keys=True),
+                DashboardView(dashboard=self._get_view(k), files=self._get_files(k)),
+            )
 
     @property
-    def views_json(self) -> dict[str, list[EmumeratedWidgetSingleView]]:
+    def views_json(self) -> dict[str, DashboardView]:
         """A JSON-serializable dictionary for all possible views of the dashboard,
         keyed by JSON-stringified representations of the views keys.
         """
@@ -267,9 +298,17 @@ AllNestedWidgetList = list[list[GroupedOrSingleWidget]]
 PartiallyNestedWidgetList = list[list[GroupedOrSingleWidget] | GroupedOrSingleWidget]
 NestedWidgetList = AllNestedWidgetList | PartiallyNestedWidgetList
 
+GroupedOrSingleFile = GroupedFiles | FilesListSingleView
 
-def _flatten(possibly_nested: NestedWidgetList | FlatWidgetList) -> FlatWidgetList:
-    """Transform a possibly nested list of widgets into a flat list of widgets.
+FlatFileList = list[GroupedOrSingleFile] | list[GroupedFiles] | list[FilesListSingleView]
+
+AllNestedFileList = list[list[GroupedOrSingleFile]]
+PartiallyNestedFileList = list[list[GroupedOrSingleFile] | GroupedOrSingleFile]
+NestedFileList = AllNestedFileList | PartiallyNestedFileList
+
+
+def _flatten(possibly_nested: list) -> list:
+    """Transform a possibly nested list into a flat list.
 
     Only works for max depth 2.
 
@@ -316,6 +355,10 @@ def gather_dashboard(
     ] = None,
     time_range: Annotated[TimeRange | SkipJsonSchema[None], Field(description="Time range filter")] = None,
     warning: Annotated[str | SkipJsonSchema[None], Field(exclude=True)] = None,
+    files: Annotated[
+        NestedFileList | FlatFileList | GroupedOrSingleFile | SkipJsonSchema[None],
+        Field(description="Files to associate with the dashboard views.", exclude=True),
+    ] = None,
 ) -> Annotated[Dashboard, Field()]:
     # if the input is any kind of list, try to flatten it because it might be nested
     # if not a list, make it a single-element list to allow uniform handling below
@@ -349,10 +392,19 @@ def gather_dashboard(
         )
         time_zone_label = time_range.timezone.label
 
+    # normalize the (possibly nested, possibly single) files input to a single GroupedFiles
+    grouped_files: GroupedFiles | None = None
+    if files is not None:
+        as_flat_files = _flatten(files) if isinstance(files, list) else [files]
+        grouped_files = GroupedFiles(views={})
+        for f in as_flat_files:
+            grouped_files |= GroupedFiles.from_single_view(f) if isinstance(f, FilesListSingleView) else f
+
     return Dashboard(
         widgets=grouped_widgets,
         grouper_choices=(grouper_choices if groupers else None),
         keys=(sorted(list(all_view_keys)) if groupers else None),
+        files=grouped_files,
         metadata=Metadata(
             title=details.name,
             description=details.description,

--- a/ecoscope/platform/tasks/results/_dashboard.py
+++ b/ecoscope/platform/tasks/results/_dashboard.py
@@ -160,13 +160,19 @@ class Dashboard(BaseModel):
         ]
 
     def _get_files(self, view: CompositeFilter | None) -> list[DashboardFile]:
-        """Get the files associated with a view. If the dashboard's files are ungrouped
-        (i.e. only have a `None` key), request `None` for that view, mirroring `_get_view`.
+        """Get the files associated with a view. Files keyed by `None` are ungrouped/global:
+        they apply to every view, so they are included in addition to any files keyed to the
+        requested `view`. This means a dashboard can combine ungrouped files (a single `None`
+        key) with grouped files (per-view keys) and both surface in each view.
         """
         if self.files is None:
             return []
-        key = view if list(self.files.views) != [None] else None
-        return [DashboardFile(path=p) for p in self.files.get_view(key)]
+        # global (ungrouped) files apply to every view...
+        paths = list(self.files.get_view(None))
+        # ...plus any files specific to the requested view
+        if view is not None:
+            paths += self.files.get_view(view)
+        return [DashboardFile(path=p) for p in paths]
 
     def _iter_views_json(
         self,

--- a/ecoscope/platform/tasks/results/_widget_tasks.py
+++ b/ecoscope/platform/tasks/results/_widget_tasks.py
@@ -26,9 +26,13 @@ def _fallback_to_none(obj: WidgetData | SkipSentinel) -> WidgetData | None:
     return None if isinstance(obj, SkipSentinel) else obj
 
 
-def _fallback_to_empty_list(obj: Path | list[Path] | SkipSentinel) -> Path | list[Path]:
+def _fallback_to_empty_list(obj: Path | list[Path] | list[SkipSentinel] | SkipSentinel) -> Path | list[Path]:
     """Fallback function to convert SkipSentinel to an empty list."""
-    return [] if isinstance(obj, SkipSentinel) else obj
+    if isinstance(obj, SkipSentinel) or (
+        isinstance(obj, list) and all([isinstance(item, SkipSentinel) for item in obj])
+    ):
+        return []
+    return obj
 
 
 @register()

--- a/ecoscope/platform/tasks/results/_widget_tasks.py
+++ b/ecoscope/platform/tasks/results/_widget_tasks.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 from pydantic import Field
@@ -7,6 +8,8 @@ from wt_task.skip import SkippedDependencyFallback, SkipSentinel
 from ecoscope.platform.annotations import AdvancedField
 from ecoscope.platform.indexes import CompositeFilter
 from ecoscope.platform.tasks.results._widget_types import (
+    FilesListSingleView,
+    GroupedFiles,
     GroupedWidget,
     GroupedWidgetMergeKey,
     MapWidgetData,
@@ -21,6 +24,11 @@ from ecoscope.platform.tasks.transformation._unit import Quantity
 def _fallback_to_none(obj: WidgetData | SkipSentinel) -> WidgetData | None:
     """Fallback function to convert SkipSentinel to None."""
     return None if isinstance(obj, SkipSentinel) else obj
+
+
+def _fallback_to_empty_list(obj: list[Path] | SkipSentinel) -> list[Path]:
+    """Fallback function to convert SkipSentinel to an empty list."""
+    return [] if isinstance(obj, SkipSentinel) else obj
 
 
 @register()
@@ -252,3 +260,50 @@ def merge_widget_views(
         else:
             merged[gw.merge_key] |= gw
     return list(merged.values())
+
+
+@register()
+def create_files_list_single_view(
+    files: Annotated[
+        list[Path],
+        Field(description="Paths to the files for this view"),
+        SkippedDependencyFallback(_fallback_to_empty_list),
+    ],
+    view: Annotated[
+        CompositeFilter | None,
+        Field(description="If grouped, the view of the files", exclude=True),
+    ] = None,
+) -> Annotated[FilesListSingleView, Field(description="The files for a single view")]:
+    """Create a list of files associated with a single view.
+
+    Args:
+        files: Paths to the files for this view.
+        view: If grouped, the view of the files.
+
+    Returns:
+        The files for a single view.
+    """
+    return FilesListSingleView(files=files, view=view)
+
+
+@register()
+def merge_file_views(
+    files: Annotated[
+        list[FilesListSingleView],
+        Field(description="The file views to merge", exclude=True),
+    ],
+) -> Annotated[GroupedFiles, Field(description="The merged grouped files")]:
+    """Merge file single-views into a single `GroupedFiles`.
+
+    Files for the same view are concatenated.
+
+    Args:
+        files: The file views to merge.
+
+    Returns:
+        The merged grouped files.
+    """
+    merged = GroupedFiles(views={})
+    for f in files:
+        merged |= GroupedFiles.from_single_view(f)
+    return merged

--- a/ecoscope/platform/tasks/results/_widget_tasks.py
+++ b/ecoscope/platform/tasks/results/_widget_tasks.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, cast
 
 from pydantic import Field
 from wt_registry import register
@@ -32,7 +32,7 @@ def _fallback_to_empty_list(obj: Path | list[Path] | list[SkipSentinel] | SkipSe
         isinstance(obj, list) and all([isinstance(item, SkipSentinel) for item in obj])
     ):
         return []
-    return obj
+    return cast(Path | list[Path], obj)
 
 
 @register()

--- a/ecoscope/platform/tasks/results/_widget_tasks.py
+++ b/ecoscope/platform/tasks/results/_widget_tasks.py
@@ -26,7 +26,7 @@ def _fallback_to_none(obj: WidgetData | SkipSentinel) -> WidgetData | None:
     return None if isinstance(obj, SkipSentinel) else obj
 
 
-def _fallback_to_empty_list(obj: list[Path] | SkipSentinel) -> list[Path]:
+def _fallback_to_empty_list(obj: Path | list[Path] | SkipSentinel) -> Path | list[Path]:
     """Fallback function to convert SkipSentinel to an empty list."""
     return [] if isinstance(obj, SkipSentinel) else obj
 
@@ -263,10 +263,10 @@ def merge_widget_views(
 
 
 @register()
-def create_files_list_single_view(
+def create_files_single_view(
     files: Annotated[
-        list[Path],
-        Field(description="Paths to the files for this view"),
+        Path | list[Path],
+        Field(description="A file, or list of files, for this view"),
         SkippedDependencyFallback(_fallback_to_empty_list),
     ],
     view: Annotated[
@@ -274,16 +274,16 @@ def create_files_list_single_view(
         Field(description="If grouped, the view of the files", exclude=True),
     ] = None,
 ) -> Annotated[FilesListSingleView, Field(description="The files for a single view")]:
-    """Create a list of files associated with a single view.
+    """Create the files associated with a single view.
 
     Args:
-        files: Paths to the files for this view.
+        files: A single file, or a list of files, for this view.
         view: If grouped, the view of the files.
 
     Returns:
         The files for a single view.
     """
-    return FilesListSingleView(files=files, view=view)
+    return FilesListSingleView(files=[files] if isinstance(files, Path) else files, view=view)
 
 
 @register()

--- a/ecoscope/platform/tasks/results/_widget_types.py
+++ b/ecoscope/platform/tasks/results/_widget_types.py
@@ -77,3 +77,42 @@ class GroupedWidget(WidgetBase):
             )
         self.views.update(other.views)
         return self
+
+
+@dataclass
+class FilesListSingleView:
+    """A list of files associated with a single view of a dashboard.
+    Mirrors `WidgetSingleView`, but carries a list of file paths rather than widget data.
+    """
+
+    files: list[Path]
+    view: CompositeFilter | None = None
+
+
+@dataclass
+class GroupedFiles:
+    """The files associated with a dashboard across all of its views. Mirrors `GroupedWidget`,
+    but the per-view value is a list of file paths. Unlike a widget, files are not titled, so
+    a dashboard has a single `GroupedFiles` and there is no `merge_key`.
+    """
+
+    views: dict[CompositeFilter | None, list[Path]]
+
+    @classmethod
+    def from_single_view(cls, view: FilesListSingleView) -> "GroupedFiles":
+        """Construct a GroupedFiles from a FilesListSingleView.
+        The resulting GroupedFiles will have a single view.
+        """
+        return cls(views={view.view: view.files})
+
+    def get_view(self, view: CompositeFilter | None) -> list[Path]:
+        """Get the list of files for a specific view, or an empty list if there are none."""
+        return self.views.get(view, [])
+
+    def __ior__(self, other: "GroupedFiles") -> "GroupedFiles":
+        """Implements the in-place or operator, i.e. `|=`, used to merge two GroupedFiles.
+        Files for the same view key are concatenated rather than overwritten.
+        """
+        for key, paths in other.views.items():
+            self.views.setdefault(key, []).extend(paths)
+        return self

--- a/tests/platform/tasks/test_dashboard.py
+++ b/tests/platform/tasks/test_dashboard.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +12,11 @@ from ecoscope.platform.tasks.results._dashboard import (
     EmumeratedWidgetSingleView,
     Metadata,
 )
-from ecoscope.platform.tasks.results._widget_types import GroupedWidget
+from ecoscope.platform.tasks.results._widget_types import (
+    FilesListSingleView,
+    GroupedFiles,
+    GroupedWidget,
+)
 
 DashboardFixture = tuple[list[GroupedWidget], Dashboard]
 
@@ -121,38 +126,44 @@ def test__get_view(single_filter_dashboard: DashboardFixture):
 def test_model_dump_views(single_filter_dashboard: DashboardFixture):
     _, dashboard = single_filter_dashboard
     assert dashboard.model_dump()["views"] == {
-        '{"TemporalGrouper_%B": "January"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/precomputed/jan/map.html",
-                "is_filtered": True,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A Cool Plot",
-                "data": "/path/to/precomputed/jan/plot.html",
-                "is_filtered": True,
-            },
-        ],
-        '{"TemporalGrouper_%B": "February"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/precomputed/feb/map.html",
-                "is_filtered": True,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A Cool Plot",
-                "data": "/path/to/precomputed/feb/plot.html",
-                "is_filtered": True,
-            },
-        ],
+        '{"TemporalGrouper_%B": "January"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/precomputed/jan/map.html",
+                    "is_filtered": True,
+                },
+                {
+                    "id": 1,
+                    "widget_type": "graph",
+                    "title": "A Cool Plot",
+                    "data": "/path/to/precomputed/jan/plot.html",
+                    "is_filtered": True,
+                },
+            ],
+            "files": [],
+        },
+        '{"TemporalGrouper_%B": "February"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/precomputed/feb/map.html",
+                    "is_filtered": True,
+                },
+                {
+                    "id": 1,
+                    "widget_type": "graph",
+                    "title": "A Cool Plot",
+                    "data": "/path/to/precomputed/feb/plot.html",
+                    "is_filtered": True,
+                },
+            ],
+            "files": [],
+        },
     }
 
 
@@ -272,24 +283,30 @@ def test__get_view_two_part_key(two_filter_dashboard: DashboardFixture):
 def test_model_dump_views_two_filter(two_filter_dashboard: DashboardFixture):
     _, dashboard = two_filter_dashboard
     assert dashboard.model_dump()["views"] == {
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/jan/2022/map.html",
-                "is_filtered": True,
-            },
-        ],
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2023"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/jan/2023/map.html",
-                "is_filtered": True,
-            },
-        ],
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/jan/2022/map.html",
+                    "is_filtered": True,
+                },
+            ],
+            "files": [],
+        },
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2023"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/jan/2023/map.html",
+                    "is_filtered": True,
+                },
+            ],
+            "files": [],
+        },
     }
 
 
@@ -441,24 +458,30 @@ def test_model_dump_views_three_filter(three_filter_dashboard: DashboardFixture)
     assert dashboard.model_dump()["views"] == {
         # Note sort_keys=True in `json.dumps` in _iter_views_json method of Dashboard
         # results in the json keys being ordered differently than the keys in the tuple
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "jo"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/jan/2022/jo/map.html",
-                "is_filtered": True,
-            },
-        ],
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "zo"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/jan/2022/zo/map.html",
-                "is_filtered": True,
-            },
-        ],
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "jo"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/jan/2022/jo/map.html",
+                    "is_filtered": True,
+                },
+            ],
+            "files": [],
+        },
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "zo"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/jan/2022/zo/map.html",
+                    "is_filtered": True,
+                },
+            ],
+            "files": [],
+        },
     }
 
 
@@ -606,38 +629,44 @@ def test__get_view_with_none_views(dashboard_with_none_views: DashboardFixture):
 def test_model_dump_views_with_none_views(dashboard_with_none_views: DashboardFixture):
     _, dashboard = dashboard_with_none_views
     assert dashboard.model_dump()["views"] == {
-        '{"TemporalGrouper_%B": "January"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/precomputed/jan/map.html",
-                "is_filtered": True,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A plot with only one view and no groupers",
-                "data": "/path/to/precomputed/single/plot.html",
-                "is_filtered": False,
-            },
-        ],
-        '{"TemporalGrouper_%B": "February"}': [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A Great Map",
-                "data": "/path/to/precomputed/feb/map.html",
-                "is_filtered": True,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A plot with only one view and no groupers",
-                "data": "/path/to/precomputed/single/plot.html",
-                "is_filtered": False,
-            },
-        ],
+        '{"TemporalGrouper_%B": "January"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/precomputed/jan/map.html",
+                    "is_filtered": True,
+                },
+                {
+                    "id": 1,
+                    "widget_type": "graph",
+                    "title": "A plot with only one view and no groupers",
+                    "data": "/path/to/precomputed/single/plot.html",
+                    "is_filtered": False,
+                },
+            ],
+            "files": [],
+        },
+        '{"TemporalGrouper_%B": "February"}': {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A Great Map",
+                    "data": "/path/to/precomputed/feb/map.html",
+                    "is_filtered": True,
+                },
+                {
+                    "id": 1,
+                    "widget_type": "graph",
+                    "title": "A plot with only one view and no groupers",
+                    "data": "/path/to/precomputed/single/plot.html",
+                    "is_filtered": False,
+                },
+            ],
+            "files": [],
+        },
     }
 
 
@@ -735,22 +764,25 @@ def test_model_dump_views_with_all_none_views(
 ):
     _, dashboard = dashboard_with_all_none_views
     assert dashboard.model_dump()["views"] == {
-        "{}": [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A map with only one view and no groupers",
-                "data": "/path/to/precomputed/single/map.html",
-                "is_filtered": False,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A plot with only one view and no groupers",
-                "data": "/path/to/precomputed/single/plot.html",
-                "is_filtered": False,
-            },
-        ],
+        "{}": {
+            "dashboard": [
+                {
+                    "id": 0,
+                    "widget_type": "map",
+                    "title": "A map with only one view and no groupers",
+                    "data": "/path/to/precomputed/single/map.html",
+                    "is_filtered": False,
+                },
+                {
+                    "id": 1,
+                    "widget_type": "graph",
+                    "title": "A plot with only one view and no groupers",
+                    "data": "/path/to/precomputed/single/plot.html",
+                    "is_filtered": False,
+                },
+            ],
+            "files": [],
+        },
     }
 
 
@@ -792,38 +824,44 @@ def outer_join_dashboard() -> Dashboard:
 
 def test_gather_dashboard_views_outer_join(outer_join_dashboard: Dashboard):
     dashboard_json = outer_join_dashboard.model_dump()
-    assert dashboard_json["views"]['{"TemporalGrouper_%B": "January"}'] == [
-        {
-            "id": 0,
-            "widget_type": "map",
-            "title": "A great map that happens to have only january data",
-            "data": "/path/to/precomputed/jan/map.html",
-            "is_filtered": True,
-        },
-        {
-            "id": 1,
-            "widget_type": "graph",
-            "title": "A plot that happens to have only february data",
-            "data": None,  # this is the outer join behavior in action
-            "is_filtered": False,
-        },
-    ]
-    assert dashboard_json["views"]['{"TemporalGrouper_%B": "February"}'] == [
-        {
-            "id": 0,
-            "widget_type": "map",
-            "title": "A great map that happens to have only january data",
-            "data": None,  # and this is the outer join behavior in action
-            "is_filtered": True,
-        },
-        {
-            "id": 1,
-            "widget_type": "graph",
-            "title": "A plot that happens to have only february data",
-            "data": "/path/to/precomputed/feb/plot.html",
-            "is_filtered": False,
-        },
-    ]
+    assert dashboard_json["views"]['{"TemporalGrouper_%B": "January"}'] == {
+        "dashboard": [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A great map that happens to have only january data",
+                "data": "/path/to/precomputed/jan/map.html",
+                "is_filtered": True,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A plot that happens to have only february data",
+                "data": None,  # this is the outer join behavior in action
+                "is_filtered": False,
+            },
+        ],
+        "files": [],
+    }
+    assert dashboard_json["views"]['{"TemporalGrouper_%B": "February"}'] == {
+        "dashboard": [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A great map that happens to have only january data",
+                "data": None,  # and this is the outer join behavior in action
+                "is_filtered": True,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A plot that happens to have only february data",
+                "data": "/path/to/precomputed/feb/plot.html",
+                "is_filtered": False,
+            },
+        ],
+        "files": [],
+    }
     # and note that the filters include all the months, even though no individual
     # widget has data for all of the months. this is also the outer join behavior.
     assert dashboard_json["filters"]["schema"]["properties"]["TemporalGrouper_%B"] == {
@@ -897,3 +935,52 @@ def test_gather_dashboard_with_no_time_range(single_filter_dashboard: DashboardF
         groupers=[TemporalGrouper(temporal_index=Month())],
     )
     assert_dashboards_equal(dashboard, expected_dashboard)
+
+
+def test_model_dump_views_with_files(single_filter_dashboard: DashboardFixture):
+    _, dashboard = single_filter_dashboard
+    jan_key = (("TemporalGrouper_%B", "=", "January"),)
+    dashboard.files = GroupedFiles(views={jan_key: [Path("/tmp/results/jan_events.parquet")]})
+
+    views = dashboard.model_dump(mode="json")["views"]
+    # widgets are nested under "dashboard", files under "files"
+    assert len(views['{"TemporalGrouper_%B": "January"}']["dashboard"]) == 2
+    assert views['{"TemporalGrouper_%B": "January"}']["files"] == [{"path": "/tmp/results/jan_events.parquet"}]
+    # february has no associated files
+    assert views['{"TemporalGrouper_%B": "February"}']["files"] == []
+
+
+def test_model_dump_views_with_ungrouped_files(dashboard_with_all_none_views: DashboardFixture):
+    _, dashboard = dashboard_with_all_none_views
+    dashboard.files = GroupedFiles(views={None: [Path("/tmp/results/all.parquet")]})
+
+    views = dashboard.model_dump(mode="json")["views"]
+    assert views["{}"]["files"] == [{"path": "/tmp/results/all.parquet"}]
+
+
+def test_gather_dashboard_with_files(single_filter_dashboard: DashboardFixture):
+    grouped_widgets, _ = single_filter_dashboard
+    jan_key = (("TemporalGrouper_%B", "=", "January"),)
+    feb_key = (("TemporalGrouper_%B", "=", "February"),)
+
+    dashboard: Dashboard = gather_dashboard(
+        details=WorkflowDetails(
+            name="A Great Dashboard",
+            description="A dashboard with a map and a plot",
+        ),
+        widgets=grouped_widgets,
+        groupers=[TemporalGrouper(temporal_index=Month())],
+        files=[
+            FilesListSingleView(files=[Path("/tmp/a.parquet")], view=jan_key),
+            FilesListSingleView(files=[Path("/tmp/b.parquet")], view=feb_key),
+        ],
+    )
+    assert dashboard.files == GroupedFiles(
+        views={
+            jan_key: [Path("/tmp/a.parquet")],
+            feb_key: [Path("/tmp/b.parquet")],
+        }
+    )
+    views = dashboard.model_dump(mode="json")["views"]
+    assert views['{"TemporalGrouper_%B": "January"}']["files"] == [{"path": "/tmp/a.parquet"}]
+    assert views['{"TemporalGrouper_%B": "February"}']["files"] == [{"path": "/tmp/b.parquet"}]

--- a/tests/platform/tasks/test_dashboard.py
+++ b/tests/platform/tasks/test_dashboard.py
@@ -126,44 +126,38 @@ def test__get_view(single_filter_dashboard: DashboardFixture):
 def test_model_dump_views(single_filter_dashboard: DashboardFixture):
     _, dashboard = single_filter_dashboard
     assert dashboard.model_dump()["views"] == {
-        '{"TemporalGrouper_%B": "January"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/precomputed/jan/map.html",
-                    "is_filtered": True,
-                },
-                {
-                    "id": 1,
-                    "widget_type": "graph",
-                    "title": "A Cool Plot",
-                    "data": "/path/to/precomputed/jan/plot.html",
-                    "is_filtered": True,
-                },
-            ],
-            "files": [],
-        },
-        '{"TemporalGrouper_%B": "February"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/precomputed/feb/map.html",
-                    "is_filtered": True,
-                },
-                {
-                    "id": 1,
-                    "widget_type": "graph",
-                    "title": "A Cool Plot",
-                    "data": "/path/to/precomputed/feb/plot.html",
-                    "is_filtered": True,
-                },
-            ],
-            "files": [],
-        },
+        '{"TemporalGrouper_%B": "January"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/precomputed/jan/map.html",
+                "is_filtered": True,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A Cool Plot",
+                "data": "/path/to/precomputed/jan/plot.html",
+                "is_filtered": True,
+            },
+        ],
+        '{"TemporalGrouper_%B": "February"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/precomputed/feb/map.html",
+                "is_filtered": True,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A Cool Plot",
+                "data": "/path/to/precomputed/feb/plot.html",
+                "is_filtered": True,
+            },
+        ],
     }
 
 
@@ -283,30 +277,24 @@ def test__get_view_two_part_key(two_filter_dashboard: DashboardFixture):
 def test_model_dump_views_two_filter(two_filter_dashboard: DashboardFixture):
     _, dashboard = two_filter_dashboard
     assert dashboard.model_dump()["views"] == {
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/jan/2022/map.html",
-                    "is_filtered": True,
-                },
-            ],
-            "files": [],
-        },
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2023"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/jan/2023/map.html",
-                    "is_filtered": True,
-                },
-            ],
-            "files": [],
-        },
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/jan/2022/map.html",
+                "is_filtered": True,
+            },
+        ],
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2023"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/jan/2023/map.html",
+                "is_filtered": True,
+            },
+        ],
     }
 
 
@@ -458,30 +446,24 @@ def test_model_dump_views_three_filter(three_filter_dashboard: DashboardFixture)
     assert dashboard.model_dump()["views"] == {
         # Note sort_keys=True in `json.dumps` in _iter_views_json method of Dashboard
         # results in the json keys being ordered differently than the keys in the tuple
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "jo"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/jan/2022/jo/map.html",
-                    "is_filtered": True,
-                },
-            ],
-            "files": [],
-        },
-        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "zo"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/jan/2022/zo/map.html",
-                    "is_filtered": True,
-                },
-            ],
-            "files": [],
-        },
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "jo"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/jan/2022/jo/map.html",
+                "is_filtered": True,
+            },
+        ],
+        '{"TemporalGrouper_%B": "January", "TemporalGrouper_%Y": "2022", "subject_name": "zo"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/jan/2022/zo/map.html",
+                "is_filtered": True,
+            },
+        ],
     }
 
 
@@ -629,44 +611,38 @@ def test__get_view_with_none_views(dashboard_with_none_views: DashboardFixture):
 def test_model_dump_views_with_none_views(dashboard_with_none_views: DashboardFixture):
     _, dashboard = dashboard_with_none_views
     assert dashboard.model_dump()["views"] == {
-        '{"TemporalGrouper_%B": "January"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/precomputed/jan/map.html",
-                    "is_filtered": True,
-                },
-                {
-                    "id": 1,
-                    "widget_type": "graph",
-                    "title": "A plot with only one view and no groupers",
-                    "data": "/path/to/precomputed/single/plot.html",
-                    "is_filtered": False,
-                },
-            ],
-            "files": [],
-        },
-        '{"TemporalGrouper_%B": "February"}': {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A Great Map",
-                    "data": "/path/to/precomputed/feb/map.html",
-                    "is_filtered": True,
-                },
-                {
-                    "id": 1,
-                    "widget_type": "graph",
-                    "title": "A plot with only one view and no groupers",
-                    "data": "/path/to/precomputed/single/plot.html",
-                    "is_filtered": False,
-                },
-            ],
-            "files": [],
-        },
+        '{"TemporalGrouper_%B": "January"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/precomputed/jan/map.html",
+                "is_filtered": True,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A plot with only one view and no groupers",
+                "data": "/path/to/precomputed/single/plot.html",
+                "is_filtered": False,
+            },
+        ],
+        '{"TemporalGrouper_%B": "February"}': [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A Great Map",
+                "data": "/path/to/precomputed/feb/map.html",
+                "is_filtered": True,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A plot with only one view and no groupers",
+                "data": "/path/to/precomputed/single/plot.html",
+                "is_filtered": False,
+            },
+        ],
     }
 
 
@@ -764,25 +740,22 @@ def test_model_dump_views_with_all_none_views(
 ):
     _, dashboard = dashboard_with_all_none_views
     assert dashboard.model_dump()["views"] == {
-        "{}": {
-            "dashboard": [
-                {
-                    "id": 0,
-                    "widget_type": "map",
-                    "title": "A map with only one view and no groupers",
-                    "data": "/path/to/precomputed/single/map.html",
-                    "is_filtered": False,
-                },
-                {
-                    "id": 1,
-                    "widget_type": "graph",
-                    "title": "A plot with only one view and no groupers",
-                    "data": "/path/to/precomputed/single/plot.html",
-                    "is_filtered": False,
-                },
-            ],
-            "files": [],
-        },
+        "{}": [
+            {
+                "id": 0,
+                "widget_type": "map",
+                "title": "A map with only one view and no groupers",
+                "data": "/path/to/precomputed/single/map.html",
+                "is_filtered": False,
+            },
+            {
+                "id": 1,
+                "widget_type": "graph",
+                "title": "A plot with only one view and no groupers",
+                "data": "/path/to/precomputed/single/plot.html",
+                "is_filtered": False,
+            },
+        ],
     }
 
 
@@ -824,44 +797,38 @@ def outer_join_dashboard() -> Dashboard:
 
 def test_gather_dashboard_views_outer_join(outer_join_dashboard: Dashboard):
     dashboard_json = outer_join_dashboard.model_dump()
-    assert dashboard_json["views"]['{"TemporalGrouper_%B": "January"}'] == {
-        "dashboard": [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A great map that happens to have only january data",
-                "data": "/path/to/precomputed/jan/map.html",
-                "is_filtered": True,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A plot that happens to have only february data",
-                "data": None,  # this is the outer join behavior in action
-                "is_filtered": False,
-            },
-        ],
-        "files": [],
-    }
-    assert dashboard_json["views"]['{"TemporalGrouper_%B": "February"}'] == {
-        "dashboard": [
-            {
-                "id": 0,
-                "widget_type": "map",
-                "title": "A great map that happens to have only january data",
-                "data": None,  # and this is the outer join behavior in action
-                "is_filtered": True,
-            },
-            {
-                "id": 1,
-                "widget_type": "graph",
-                "title": "A plot that happens to have only february data",
-                "data": "/path/to/precomputed/feb/plot.html",
-                "is_filtered": False,
-            },
-        ],
-        "files": [],
-    }
+    assert dashboard_json["views"]['{"TemporalGrouper_%B": "January"}'] == [
+        {
+            "id": 0,
+            "widget_type": "map",
+            "title": "A great map that happens to have only january data",
+            "data": "/path/to/precomputed/jan/map.html",
+            "is_filtered": True,
+        },
+        {
+            "id": 1,
+            "widget_type": "graph",
+            "title": "A plot that happens to have only february data",
+            "data": None,  # this is the outer join behavior in action
+            "is_filtered": False,
+        },
+    ]
+    assert dashboard_json["views"]['{"TemporalGrouper_%B": "February"}'] == [
+        {
+            "id": 0,
+            "widget_type": "map",
+            "title": "A great map that happens to have only january data",
+            "data": None,  # and this is the outer join behavior in action
+            "is_filtered": True,
+        },
+        {
+            "id": 1,
+            "widget_type": "graph",
+            "title": "A plot that happens to have only february data",
+            "data": "/path/to/precomputed/feb/plot.html",
+            "is_filtered": False,
+        },
+    ]
     # and note that the filters include all the months, even though no individual
     # widget has data for all of the months. this is also the outer join behavior.
     assert dashboard_json["filters"]["schema"]["properties"]["TemporalGrouper_%B"] == {
@@ -1035,3 +1002,55 @@ def test_gather_dashboard_with_ungrouped_and_grouped_files(single_filter_dashboa
         {"path": "/tmp/ungrouped.csv"},
         {"path": "/tmp/feb.csv"},
     ]
+
+
+def test_model_dump_views_no_files_preserves_bare_list_shape(single_filter_dashboard: DashboardFixture):
+    # a dashboard with no associated files serializes each view as a bare list of widgets,
+    # preserving the historical output shape (no "dashboard"/"files" wrapper).
+    _, dashboard = single_filter_dashboard
+    assert dashboard.files is None
+
+    views = dashboard.model_dump(mode="json")["views"]
+    jan = views['{"TemporalGrouper_%B": "January"}']
+    assert isinstance(jan, list)
+    assert jan[0]["widget_type"] == "map"
+
+
+def test_model_dump_views_with_files_uses_wrapper_shape(single_filter_dashboard: DashboardFixture):
+    # as soon as a dashboard has any files, every view switches to the wrapped
+    # {"dashboard": [...], "files": [...]} shape, even views with no files of their own.
+    _, dashboard = single_filter_dashboard
+    jan_key = (("TemporalGrouper_%B", "=", "January"),)
+    dashboard.files = GroupedFiles(views={jan_key: [Path("/tmp/results/jan.parquet")]})
+
+    views = dashboard.model_dump(mode="json")["views"]
+    for view in views.values():
+        assert set(view) == {"dashboard", "files"}
+
+
+def test_gather_dashboard_rejects_file_key_not_matching_view(single_filter_dashboard: DashboardFixture):
+    # files keyed to a view the dashboard doesn't have would be silently dropped at
+    # serialization time, so gather_dashboard rejects them (mirrors the grouped-widget check).
+    grouped_widgets, _ = single_filter_dashboard
+    march_key = (("TemporalGrouper_%B", "=", "March"),)  # no widget produces a March view
+
+    with pytest.raises(AssertionError, match="File view keys"):
+        gather_dashboard(
+            details=WorkflowDetails(name="A Great Dashboard", description=""),
+            widgets=grouped_widgets,
+            groupers=[TemporalGrouper(temporal_index=Month())],
+            files=[FilesListSingleView(files=[Path("/tmp/march.parquet")], view=march_key)],
+        )
+
+
+def test_gather_dashboard_rejects_grouped_files_without_groupers(single_filter_dashboard: DashboardFixture):
+    # with no groupers there are no view keys, so any non-`None` file key is invalid.
+    grouped_widgets, _ = single_filter_dashboard
+    jan_key = (("TemporalGrouper_%B", "=", "January"),)
+
+    with pytest.raises(AssertionError, match="File view keys"):
+        gather_dashboard(
+            details=WorkflowDetails(name="A Great Dashboard", description=""),
+            widgets=grouped_widgets,
+            files=[FilesListSingleView(files=[Path("/tmp/jan.parquet")], view=jan_key)],
+        )

--- a/tests/platform/tasks/test_dashboard.py
+++ b/tests/platform/tasks/test_dashboard.py
@@ -942,6 +942,7 @@ def test_model_dump_views_with_files(single_filter_dashboard: DashboardFixture):
     jan_key = (("TemporalGrouper_%B", "=", "January"),)
     dashboard.files = GroupedFiles(views={jan_key: [Path("/tmp/results/jan_events.parquet")]})
 
+    # JSON-mode dump renders Path values as strings
     views = dashboard.model_dump(mode="json")["views"]
     # widgets are nested under "dashboard", files under "files"
     assert len(views['{"TemporalGrouper_%B": "January"}']["dashboard"]) == 2
@@ -956,6 +957,31 @@ def test_model_dump_views_with_ungrouped_files(dashboard_with_all_none_views: Da
 
     views = dashboard.model_dump(mode="json")["views"]
     assert views["{}"]["files"] == [{"path": "/tmp/results/all.parquet"}]
+
+
+def test_model_dump_views_with_ungrouped_and_grouped_files(single_filter_dashboard: DashboardFixture):
+    # a dashboard can combine ungrouped (null-view) files that apply to every view with
+    # per-view (grouped) files; each view surfaces the global file plus its own.
+    _, dashboard = single_filter_dashboard
+    jan_key = (("TemporalGrouper_%B", "=", "January"),)
+    feb_key = (("TemporalGrouper_%B", "=", "February"),)
+    dashboard.files = GroupedFiles(
+        views={
+            None: [Path("/tmp/results/all_events.csv")],
+            jan_key: [Path("/tmp/results/jan.csv")],
+            feb_key: [Path("/tmp/results/feb.csv")],
+        }
+    )
+
+    views = dashboard.model_dump(mode="json")["views"]
+    assert views['{"TemporalGrouper_%B": "January"}']["files"] == [
+        {"path": "/tmp/results/all_events.csv"},
+        {"path": "/tmp/results/jan.csv"},
+    ]
+    assert views['{"TemporalGrouper_%B": "February"}']["files"] == [
+        {"path": "/tmp/results/all_events.csv"},
+        {"path": "/tmp/results/feb.csv"},
+    ]
 
 
 def test_gather_dashboard_with_files(single_filter_dashboard: DashboardFixture):
@@ -984,3 +1010,28 @@ def test_gather_dashboard_with_files(single_filter_dashboard: DashboardFixture):
     views = dashboard.model_dump(mode="json")["views"]
     assert views['{"TemporalGrouper_%B": "January"}']["files"] == [{"path": "/tmp/a.parquet"}]
     assert views['{"TemporalGrouper_%B": "February"}']["files"] == [{"path": "/tmp/b.parquet"}]
+
+
+def test_gather_dashboard_with_ungrouped_and_grouped_files(single_filter_dashboard: DashboardFixture):
+    grouped_widgets, _ = single_filter_dashboard
+    jan_key = (("TemporalGrouper_%B", "=", "January"),)
+    feb_key = (("TemporalGrouper_%B", "=", "February"),)
+
+    dashboard: Dashboard = gather_dashboard(
+        details=WorkflowDetails(name="A Great Dashboard", description=""),
+        widgets=grouped_widgets,
+        groupers=[TemporalGrouper(temporal_index=Month())],
+        files=[
+            FilesListSingleView(files=[Path("/tmp/ungrouped.csv")], view=None),
+            GroupedFiles(views={jan_key: [Path("/tmp/jan.csv")], feb_key: [Path("/tmp/feb.csv")]}),
+        ],
+    )
+    views = dashboard.model_dump(mode="json")["views"]
+    assert views['{"TemporalGrouper_%B": "January"}']["files"] == [
+        {"path": "/tmp/ungrouped.csv"},
+        {"path": "/tmp/jan.csv"},
+    ]
+    assert views['{"TemporalGrouper_%B": "February"}']["files"] == [
+        {"path": "/tmp/ungrouped.csv"},
+        {"path": "/tmp/feb.csv"},
+    ]

--- a/tests/platform/tasks/test_widgets.py
+++ b/tests/platform/tasks/test_widgets.py
@@ -5,7 +5,7 @@ import pytest
 from wt_task.skip import SKIP_SENTINEL
 
 from ecoscope.platform.tasks.results import (
-    create_files_list_single_view,
+    create_files_single_view,
     create_map_v2_widget_single_view,
     create_map_widget_single_view,
     create_plot_widget_single_view,
@@ -455,18 +455,25 @@ def test_merge_grouped_widget_views_multiple_widgets_with_none_views():
     ]
 
 
-def test_create_files_list_single_view():
+def test_create_files_single_view():
     view = (("month", "=", "january"), ("year", "=", "2022"))
     files = [Path("/path/to/jan/2022/a.parquet"), Path("/path/to/jan/2022/b.parquet")]
 
-    single_view = create_files_list_single_view(files, view)
+    single_view = create_files_single_view(files, view)
     assert single_view == FilesListSingleView(files=files, view=view)
 
 
-def test_create_files_list_single_view_no_view():
+def test_create_files_single_view_single_path():
+    # a single Path is normalized to a one-element list
+    view = (("month", "=", "january"),)
+    single_view = create_files_single_view(Path("/path/to/a.parquet"), view)
+    assert single_view == FilesListSingleView(files=[Path("/path/to/a.parquet")], view=view)
+
+
+def test_create_files_single_view_no_view():
     files = [Path("/path/to/a.parquet")]
 
-    single_view = create_files_list_single_view(files)
+    single_view = create_files_single_view(files)
     assert single_view == FilesListSingleView(files=files, view=None)
 
 

--- a/tests/platform/tasks/test_widgets.py
+++ b/tests/platform/tasks/test_widgets.py
@@ -1,20 +1,29 @@
 import re
+from pathlib import Path
 
 import pytest
+from wt_task.skip import SKIP_SENTINEL
 
 from ecoscope.platform.tasks.results import (
+    create_files_list_single_view,
     create_map_v2_widget_single_view,
     create_map_widget_single_view,
     create_plot_widget_single_view,
     create_single_value_widget_single_view,
     create_table_widget_single_view,
     create_text_widget_single_view,
+    merge_file_views,
     merge_widget_views,
 )
 from ecoscope.platform.tasks.results._pydeck import DeckJsonSpec
 from ecoscope.platform.tasks.results._widget_tasks import (
     GroupedWidget,
     WidgetSingleView,
+    _fallback_to_empty_list,
+)
+from ecoscope.platform.tasks.results._widget_types import (
+    FilesListSingleView,
+    GroupedFiles,
 )
 from ecoscope.platform.tasks.transformation._unit import Quantity, Unit
 
@@ -444,3 +453,84 @@ def test_merge_grouped_widget_views_multiple_widgets_with_none_views():
             is_filtered=False,
         ),
     ]
+
+
+def test_create_files_list_single_view():
+    view = (("month", "=", "january"), ("year", "=", "2022"))
+    files = [Path("/path/to/jan/2022/a.parquet"), Path("/path/to/jan/2022/b.parquet")]
+
+    single_view = create_files_list_single_view(files, view)
+    assert single_view == FilesListSingleView(files=files, view=view)
+
+
+def test_create_files_list_single_view_no_view():
+    files = [Path("/path/to/a.parquet")]
+
+    single_view = create_files_list_single_view(files)
+    assert single_view == FilesListSingleView(files=files, view=None)
+
+
+def test_fallback_to_empty_list():
+    # a skipped upstream dependency falls back to an empty list
+    assert _fallback_to_empty_list(SKIP_SENTINEL) == []
+    # a real list passes through unchanged
+    files = [Path("/path/to/a.parquet")]
+    assert _fallback_to_empty_list(files) is files
+
+
+def test_merge_file_views_distinct_keys():
+    jan = (("month", "=", "january"),)
+    feb = (("month", "=", "february"),)
+
+    merged = merge_file_views(
+        [
+            FilesListSingleView(files=[Path("/jan.parquet")], view=jan),
+            FilesListSingleView(files=[Path("/feb.parquet")], view=feb),
+        ]
+    )
+    assert merged == GroupedFiles(
+        views={
+            jan: [Path("/jan.parquet")],
+            feb: [Path("/feb.parquet")],
+        }
+    )
+
+
+def test_merge_file_views_duplicate_keys_concatenate():
+    jan = (("month", "=", "january"),)
+
+    merged = merge_file_views(
+        [
+            FilesListSingleView(files=[Path("/jan_a.parquet")], view=jan),
+            FilesListSingleView(files=[Path("/jan_b.parquet")], view=jan),
+        ]
+    )
+    assert merged == GroupedFiles(views={jan: [Path("/jan_a.parquet"), Path("/jan_b.parquet")]})
+
+
+def test_grouped_files_from_single_view():
+    jan = (("month", "=", "january"),)
+    single_view = FilesListSingleView(files=[Path("/jan.parquet")], view=jan)
+    assert GroupedFiles.from_single_view(single_view) == GroupedFiles(views={jan: [Path("/jan.parquet")]})
+
+
+def test_grouped_files_get_view():
+    jan = (("month", "=", "january"),)
+    feb = (("month", "=", "february"),)
+    grouped = GroupedFiles(views={jan: [Path("/jan.parquet")]})
+    assert grouped.get_view(jan) == [Path("/jan.parquet")]
+    # a missing view returns an empty list rather than raising
+    assert grouped.get_view(feb) == []
+
+
+def test_grouped_files_ior_concatenates():
+    jan = (("month", "=", "january"),)
+    feb = (("month", "=", "february"),)
+    grouped = GroupedFiles(views={jan: [Path("/jan_a.parquet")]})
+    grouped |= GroupedFiles(views={jan: [Path("/jan_b.parquet")], feb: [Path("/feb.parquet")]})
+    assert grouped == GroupedFiles(
+        views={
+            jan: [Path("/jan_a.parquet"), Path("/jan_b.parquet")],
+            feb: [Path("/feb.parquet")],
+        }
+    )


### PR DESCRIPTION
## :earth_americas: Summary
Closes #774 

## :package: Proposed Changes
- Adds a `files` arg to `gather_dashboard` which allows workflows to declare files as formal outputs of the workflow (as opposed to being something that implicitly happens or doesn't happen as the result of an upstream task)
  - If `files` is `None` the dashboard will serialise to the existing contract
  - If `files` is a list, empty or otherwise, the dashboard will serialise to the new contract:
```diff
        "views": {
+           "{\"All\": \"True\"}": {
+               "dashboard": [
                    {
                        "widget_type": "graph",
                        "title": "Events Bar Chart",
                        "is_filtered": true,
                        "id": 0,
                        "data": "/tmp/results/90e9447_v2.html"
                    }
+               ],
+               "files": [
+                   {
+                       "path": "/tmp/results/my_events.parquet"
+                   }
                ]
+           }
        },
```

- Adds equivalent widget tasks and types to service creating lists of file paths to feed to the dashboard
- I've tested these changes against:
  - The [events workflow](https://github.com/ecoscope-platform-workflows-releases/events/pull/212) for regression
  - A test workflow demonstrate the new contract [here](https://github.com/atmorling/test-dashboard-workflow/blob/9e635e9ce91eff40c2a6b4b22ad46fac7b1698f9/__results_snapshots__/default/test_dashboard_json%5Bdata%5D.json)

## 📋 Checklist
- [x] Corresponding ecoscope.platform tasks updated if necessary