### PR TITLE
Update ecoscope-earthranger-io-core to v0.0.24 to get DWH client bugfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ platform = [
     "cloudpathlib[gs]",
     "wt-registry>=0.2.0,<0.3.0",
     "wt-task>=0.1.0,<0.2.0",
-    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.22",
+    "ecoscope-earthranger-io-core @ git+https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core.git@v0.0.24",
     "fastapi",  # required at import time by ecoscope-earthranger-io-core but not in its core dependencies
     "pyarrow>=20",
     "geoarrow-pyarrow>=0.2.0,<0.3",

--- a/tests/platform/tasks/conftest.py
+++ b/tests/platform/tasks/conftest.py
@@ -42,6 +42,10 @@ def warehouse_observations_table():
                 "geometry": ga.array([Point(37.5 + i * 0.001, -2.5).wkb for i in range(n)]),
                 "fixtime": pa.array(list(fixtimes), type=pa.timestamp("ns", tz="UTC")),
                 "groupby_col": pa.array(subject_ids, type=pa.string()),
+                # Duplicates groupby_col, matching what the warehouse serves: io-core
+                # v0.0.23 added this so the subject id survives under the name the
+                # EarthRanger API path uses (`subject__id`, once `extra__` is stripped).
+                "extra__subject__id": pa.array(subject_ids, type=pa.string()),
                 "extra__subject__name": pa.array([f"subj-{s}" for s in subject_ids], type=pa.string()),
                 "extra__subject__subject_subtype": pa.array(["elephant"] * n, type=pa.string()),
                 "extra__subject__additional": pa.array(


### PR DESCRIPTION
## :earth_americas: Summary
Closes #808 

## :package: Proposed Changes
This PR updates `ecoscope-earthranger-io-core` to` v0.0.24` to get a DWH client bugfix affecting the subject-tracking and patrols workflow.

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary