### PR TITLE
ERDW-269: Gate DWH usage inside get_patrols behind DWH_EVENTS_ENABLED

### DIFF
--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -33,10 +33,19 @@ from ecoscope.platform.tasks.io._persist import (
 
 logger = logging.getLogger(__name__)
 
-# Temporary kill switch (ERDW-233): when False, event-related tasks bypass the
-# DWH/warehouse client and read event data from the EarthRanger API directly.
-# Observation/patrol tasks are unaffected. Flip to True (or remove the guards)
-# to re-enable DWH-backed event data.
+# Temporary kill switch (ERDW-233, ERDW-269): when False, every task whose DWH
+# read carries event data bypasses the warehouse client and reads from the
+# EarthRanger API instead. Observation tasks are unaffected and keep reading
+# from the DWH. Flip to True (or remove the guards) to re-enable DWH-backed
+# event data.
+#
+# `get_patrols` is covered because warehouse patrols nest their events:
+# `ERWarehouseClient.get_patrols` always sends `include_events=True` and offers
+# no way to turn it off, so DWH patrols cannot be enabled independently of DWH
+# events. It also must stay off until the API deployed in prod is new enough --
+# that build pins io-core v0.0.16, which predates `include_events`, so it
+# silently ignores the flag and answers with the patrol-only shape, whose
+# missing `patrol_segments` column then fails PatrolsDFSchema.
 DWH_EVENTS_ENABLED = False
 
 
@@ -873,9 +882,15 @@ def get_patrols(
     if status is None:
         status = ["done"]
 
-    if warehouse_client := _make_warehouse_client_from_env(
-        er_site_url=client.server,
-        er_api_token=SecretStr(client.token) if client.token else None,
+    # Gated on DWH_EVENTS_ENABLED: warehouse patrols nest their events, so this
+    # read is event data and follows the same switch. Unlike the event tasks, the
+    # ER-API fallback below does not reference warehouse_client, so the walrus
+    # can stay inside the condition.
+    if DWH_EVENTS_ENABLED and (
+        warehouse_client := _make_warehouse_client_from_env(
+            er_site_url=client.server,
+            er_api_token=SecretStr(client.token) if client.token else None,
+        )
     ):
         from ecoscope.io.earthranger_utils import warehouse_patrols_table_to_patrols_df
 

--- a/tests/platform/tasks/test_io_earthranger_warehouse_events.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_events.py
@@ -445,6 +445,7 @@ def test_get_events_via_warehouse_client_display_values():
     assert result["event_type_display"].tolist() == ["Human Wildlife Conflict"]
 
 
+@requires_dwh_events
 def test_get_patrols_via_warehouse_client_synthesized_shape_feeds_unpack():
     """Warehouse get_patrols is converted to the ER-native PatrolsDF shape:
     per-event synthesized geojson + per-segment time_range.start_time, and that
@@ -488,6 +489,7 @@ def test_get_patrols_via_warehouse_client_synthesized_shape_feeds_unpack():
     _assert_valid_events_gdf(events)
 
 
+@requires_dwh_events
 def test_get_patrols_via_warehouse_client_empty():
     mock_legacy_client = MagicMock()
     mock_warehouse_client = MagicMock()
@@ -844,3 +846,37 @@ def test_get_patrol_events_legacy_display_values_path():
 
     mock_legacy_client.get_patrol_events.assert_called_once()
     mock_legacy_client.get_event_type_display_names_from_events.assert_called_once()
+
+
+def test_get_patrols_respects_dwh_events_kill_switch():
+    """With the switch off, patrols come from the ER API even when the DWH is configured.
+
+    Distinct from test_get_patrols_warehouse_disabled_falls_back_to_legacy_client,
+    which simulates the warehouse not being configured at all: here a warehouse
+    client is available and must still be bypassed. Warehouse patrols nest their
+    events (the client always sends include_events=True), so they follow the
+    event kill switch rather than the observation path.
+    """
+    mock_legacy_client = MagicMock()
+    mock_legacy_client.get_patrols.return_value = pd.DataFrame()
+    mock_warehouse_client = MagicMock()
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        result = get_patrols(
+            client=mock_legacy_client,
+            time_range=_EVENT_TIME_RANGE,
+            patrol_types=["ecoscope_patrol"],
+            status=None,
+            raise_on_empty=False,
+        )
+
+    if DWH_EVENTS_ENABLED:
+        mock_warehouse_client.get_patrols.assert_called_once()
+        mock_legacy_client.get_patrols.assert_not_called()
+    else:
+        mock_legacy_client.get_patrols.assert_called_once()
+        mock_warehouse_client.get_patrols.assert_not_called()
+        assert result.empty


### PR DESCRIPTION
## :earth_americas: Summary
Closes #810 

## :package: Proposed Changes
Disables the DWH client usage in get_patrols, until the DWH API supporting events is QAed and released to prod.

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary