### PR TITLE
ERDW-249: Enable DWH Events

### DIFF
--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -33,20 +33,29 @@ from ecoscope.platform.tasks.io._persist import (
 
 logger = logging.getLogger(__name__)
 
-# Temporary kill switch (ERDW-233, ERDW-269): when False, every task whose DWH
-# read carries event data bypasses the warehouse client and reads from the
-# EarthRanger API instead. Observation tasks are unaffected and keep reading
-# from the DWH. Flip to True (or remove the guards) to re-enable DWH-backed
-# event data.
-#
-# `get_patrols` is covered because warehouse patrols nest their events:
-# `ERWarehouseClient.get_patrols` always sends `include_events=True` and offers
-# no way to turn it off, so DWH patrols cannot be enabled independently of DWH
-# events. It also must stay off until the API deployed in prod is new enough --
-# that build pins io-core v0.0.16, which predates `include_events`, so it
-# silently ignores the flag and answers with the patrol-only shape, whose
-# missing `patrol_segments` column then fails PatrolsDFSchema.
-DWH_EVENTS_ENABLED = False
+
+def _dwh_events_enabled() -> bool:
+    """Whether tasks whose DWH read carries event data may use the warehouse.
+
+    Kill switch (ERDW-233, ERDW-269, ERDW-249) for DWH-backed event data, now
+    enabled by default: set ``DWH_EVENTS_ENABLED=false`` to make every task whose
+    DWH read carries event data bypass the warehouse client and read from the
+    EarthRanger API instead. Observation tasks are unaffected and always read
+    from the DWH (subject to ``USE_EARTHRANGER_WAREHOUSE_API``).
+
+    `get_patrols` is covered because warehouse patrols nest their events:
+    `ERWarehouseClient.get_patrols` always sends ``include_events=True`` and
+    offers no way to turn it off, so DWH patrols cannot be toggled independently
+    of DWH events. That also means the warehouse API this talks to must be new
+    enough to honour ``include_events``: an older build answers with the
+    patrol-only shape, whose missing ``patrol_segments`` column then fails
+    PatrolsDFSchema. Turn this off when pointing at such a deployment.
+
+    Read from the environment on every call (like
+    `_make_warehouse_client_from_env`) so the switch can be flipped without
+    re-importing this module.
+    """
+    return os.environ.get("DWH_EVENTS_ENABLED", "true").lower() == "true"
 
 
 def _make_warehouse_client_from_env(er_site_url: str, er_api_token: SecretStr | None):
@@ -623,7 +632,7 @@ def get_patrol_events(
     # Pre-bind: the `and` below short-circuits before the walrus when events-DWH
     # is disabled, and the ER-API fallback path references warehouse_client.
     warehouse_client = None
-    if DWH_EVENTS_ENABLED and (
+    if _dwh_events_enabled() and (
         warehouse_client := _make_warehouse_client_from_env(
             er_site_url=client.server,
             er_api_token=SecretStr(client.token) if client.token else None,
@@ -703,7 +712,7 @@ def get_events(
     # Pre-bind: the `and` below short-circuits before the walrus when events-DWH
     # is disabled, and the ER-API fallback path references warehouse_client.
     warehouse_client = None
-    if DWH_EVENTS_ENABLED and (
+    if _dwh_events_enabled() and (
         warehouse_client := _make_warehouse_client_from_env(
             er_site_url=client.server,
             er_api_token=SecretStr(client.token) if client.token else None,
@@ -882,11 +891,11 @@ def get_patrols(
     if status is None:
         status = ["done"]
 
-    # Gated on DWH_EVENTS_ENABLED: warehouse patrols nest their events, so this
+    # Gated on _dwh_events_enabled(): warehouse patrols nest their events, so this
     # read is event data and follows the same switch. Unlike the event tasks, the
     # ER-API fallback below does not reference warehouse_client, so the walrus
     # can stay inside the condition.
-    if DWH_EVENTS_ENABLED and (
+    if _dwh_events_enabled() and (
         warehouse_client := _make_warehouse_client_from_env(
             er_site_url=client.server,
             er_api_token=SecretStr(client.token) if client.token else None,
@@ -996,7 +1005,7 @@ def get_event_type_display_names_from_events(
     # Pre-bind: the `and` below short-circuits before the walrus when events-DWH
     # is disabled, and the ER-API fallback path references warehouse_client.
     warehouse_client = None
-    if DWH_EVENTS_ENABLED and (
+    if _dwh_events_enabled() and (
         warehouse_client := _make_warehouse_client_from_env(
             er_site_url=client.server,
             er_api_token=SecretStr(client.token) if client.token else None,

--- a/tests/platform/tasks/test_io_earthranger_warehouse_events.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_events.py
@@ -21,14 +21,19 @@ from ecoscope.platform.tasks.io import (
     get_patrol_events,
     get_patrols,
 )
-from ecoscope.platform.tasks.io._earthranger import DWH_EVENTS_ENABLED
+from ecoscope.platform.tasks.io._earthranger import _dwh_events_enabled
 
-# ERDW-233: tests that exercise the warehouse (DWH) events path are skipped while
-# DWH_EVENTS_ENABLED is False; they auto-re-enable when the flag is flipped back.
-requires_dwh_events = pytest.mark.skipif(
-    not DWH_EVENTS_ENABLED,
-    reason="ERDW-233: DWH client disabled for events (DWH_EVENTS_ENABLED=False)",
-)
+
+@pytest.fixture
+def dwh_events_enabled(monkeypatch):
+    """Pin DWH_EVENTS_ENABLED on, regardless of the ambient environment."""
+    monkeypatch.setenv("DWH_EVENTS_ENABLED", "true")
+
+
+# Marks a test as exercising the DWH-backed event path, and pins the kill switch on
+# for it: a deployment-style DWH_EVENTS_ENABLED=false in the developer's or CI's
+# environment must not silently reroute these to the ER API and fail them.
+requires_dwh_events = pytest.mark.usefixtures("dwh_events_enabled")
 
 
 def _make_events_arrow_table(
@@ -848,35 +853,55 @@ def test_get_patrol_events_legacy_display_values_path():
     mock_legacy_client.get_event_type_display_names_from_events.assert_called_once()
 
 
-def test_get_patrols_respects_dwh_events_kill_switch():
-    """With the switch off, patrols come from the ER API even when the DWH is configured.
+def test_dwh_events_enabled_defaults_to_true(monkeypatch):
+    """ERDW-249: the DWH events path is on unless DWH_EVENTS_ENABLED says otherwise."""
+    monkeypatch.delenv("DWH_EVENTS_ENABLED", raising=False)
+    assert _dwh_events_enabled() is True
 
-    Distinct from test_get_patrols_warehouse_disabled_falls_back_to_legacy_client,
-    which simulates the warehouse not being configured at all: here a warehouse
-    client is available and must still be bypassed. Warehouse patrols nest their
-    events (the client always sends include_events=True), so they follow the
-    event kill switch rather than the observation path.
+    for value, expected in [("false", False), ("FALSE", False), ("true", True), ("True", True)]:
+        monkeypatch.setenv("DWH_EVENTS_ENABLED", value)
+        assert _dwh_events_enabled() is expected
+
+
+@pytest.mark.parametrize(
+    "task, method, kwargs",
+    [
+        (get_patrols, "get_patrols", {"patrol_types": ["ecoscope_patrol"], "status": None}),
+        (get_events, "get_events", {"event_types": ["hwc_rep"]}),
+        (
+            get_patrol_events,
+            "get_patrols",
+            {"patrol_types": ["ecoscope_patrol"], "event_types": ["hwc_rep"]},
+        ),
+    ],
+)
+def test_dwh_events_kill_switch_falls_back_to_legacy_client(monkeypatch, task, method, kwargs):
+    """With DWH_EVENTS_ENABLED=false, event data comes from the ER API even when the DWH is configured.
+
+    Distinct from the test_*_warehouse_disabled_falls_back_to_legacy_client tests,
+    which simulate the warehouse not being configured at all: here a warehouse
+    client is available and must still be bypassed. `get_patrols` is included
+    because warehouse patrols nest their events (the client always sends
+    include_events=True), so they follow the event kill switch rather than the
+    observation path.
     """
+    monkeypatch.setenv("DWH_EVENTS_ENABLED", "false")
     mock_legacy_client = MagicMock()
-    mock_legacy_client.get_patrols.return_value = pd.DataFrame()
+    mock_legacy_client.get_event_types.return_value = pd.DataFrame({"id": ["id-1"], "value": ["hwc_rep"]})
+    getattr(mock_legacy_client, task.__name__).return_value = pd.DataFrame()
     mock_warehouse_client = MagicMock()
 
     with patch(
         "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
         return_value=mock_warehouse_client,
     ):
-        result = get_patrols(
+        result = task(
             client=mock_legacy_client,
             time_range=_EVENT_TIME_RANGE,
-            patrol_types=["ecoscope_patrol"],
-            status=None,
             raise_on_empty=False,
+            **kwargs,
         )
 
-    if DWH_EVENTS_ENABLED:
-        mock_warehouse_client.get_patrols.assert_called_once()
-        mock_legacy_client.get_patrols.assert_not_called()
-    else:
-        mock_legacy_client.get_patrols.assert_called_once()
-        mock_warehouse_client.get_patrols.assert_not_called()
-        assert result.empty
+    getattr(mock_legacy_client, task.__name__).assert_called_once()
+    getattr(mock_warehouse_client, method).assert_not_called()
+    assert result.empty


### PR DESCRIPTION
## :earth_americas: Summary
Closes #815 

## :package: Proposed Changes
Turn the `DWH_EVENTS_ENABLED` ON, so `get_events`, `get_patrol_events`, `get_patrols` and   `get_event_type_display_names_from_events` can read events from the warehouse. Also let it be disabled by env var, so that we don't need to re-publish ecoscope and re-generate workflows if it needs to be disabled.

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary