### PR TITLE
ERDW-276: Fix DWH get_events failure when event details are requested

### DIFF
--- a/ecoscope/io/earthranger_utils.py
+++ b/ecoscope/io/earthranger_utils.py
@@ -1,3 +1,6 @@
+import json
+import logging
+
 import geopandas as gpd  # type: ignore[import-untyped]
 import pandas as pd
 import pyarrow as pa  # type: ignore[import-untyped]
@@ -6,6 +9,8 @@ import shapely.wkb
 from shapely.geometry import shape
 
 from ecoscope.io.utils import clean_time_cols
+
+logger = logging.getLogger(__name__)
 
 
 def clean_kwargs(addl_kwargs: dict | None = None, **kwargs) -> dict:
@@ -26,6 +31,57 @@ def normalize_column(df: pd.DataFrame, col: str, sort_columns: bool = False) -> 
 
     for k in new_cols:
         df[k] = normalized[k].values  # type: ignore[call-overload]
+
+
+def decode_raw_event_details(df: pd.DataFrame, col: str = "event_details") -> None:
+    """Decode a warehouse raw-JSON ``event_details`` column into dicts, in place.
+
+    Used by the warehouse branch of the ``get_events`` task. The warehouse serves
+    ``event_details`` as a JSON string when asked for raw details (``EVENTS_SCHEMA_V1``
+    types it ``pa.string()``); the typed-struct alternative is derived from a single
+    event type's schema and so cannot serve the multi- or all-event-type selections
+    workflows allow. The ER API path, by contrast, serves ``event_details`` already
+    parsed, and every downstream consumer -- notably ``normalize_column``
+    (``pd.json_normalize``) and the ``process_events_details`` task, which no-ops on
+    anything that is not a ``dict`` -- depends on that. Decoding here keeps both paths'
+    output identical.
+
+    A null/absent payload becomes ``{}`` rather than ``None``, matching the ER API
+    (which serves ``"event_details": {}`` for an event without details) and keeping the
+    column free of the non-dict values ``pd.json_normalize`` rejects. A value that
+    fails to parse -- or parses to a non-object, e.g. a bare JSON scalar -- also
+    becomes ``{}``, with a warning: one malformed payload should not fail a download.
+    No-ops when the column is absent or already decoded.
+    """
+    if col not in df.columns:
+        return
+
+    bad = 0
+
+    def decode(value):
+        nonlocal bad
+        if isinstance(value, dict):
+            return value
+        # None / NaN / pd.NA (the warehouse serves the column nullable) and "" are all
+        # "no details", not malformed input, so they decode quietly.
+        if not isinstance(value, str):
+            return {}
+        if value == "":
+            return {}
+        try:
+            decoded = json.loads(value)
+        except (TypeError, ValueError):
+            bad += 1
+            return {}
+        if not isinstance(decoded, dict):
+            bad += 1
+            return {}
+        return decoded
+
+    df[col] = [decode(v) for v in df[col]]
+
+    if bad:
+        logger.warning("Could not decode %s of %s `%s` JSON payloads; used {} instead.", bad, len(df), col)
 
 
 def dataframe_to_dict_or_list(events: gpd.GeoDataFrame | pd.DataFrame | dict | list[dict]) -> dict | list[dict]:

--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -722,6 +722,12 @@ def get_events(
 
         # The warehouse get_events accepts event type slugs directly, so pass the
         # values straight through — no value->id round-trip via get_event_types.
+        #
+        # raw_details: the warehouse can also serve `event_details` as structured Arrow
+        # data, but only for a single event type (the struct is derived from that type's
+        # schema), and adopting it would mean refactoring the tasks and workflows that
+        # consume the column, which expect dicts. So ask for the raw JSON form — valid
+        # for any number of event types — and decode it to dicts below.
         table = warehouse_client.get_events(
             since=time_range.since.isoformat(),
             until=time_range.until.isoformat(),
@@ -730,6 +736,7 @@ def get_events(
             include_details=include_details,
             include_updates=include_updates,
             include_related_events=include_related_events,
+            raw_details=include_details,
         )
         events_df = gpd.GeoDataFrame.from_arrow(table).rename(
             columns={
@@ -738,6 +745,10 @@ def get_events(
                 "event_time": "time",
             }
         )
+        if include_details:
+            from ecoscope.io.earthranger_utils import decode_raw_event_details
+
+            decode_raw_event_details(events_df)
         # Parity with the legacy path (geometry_from_event_geojson): when
         # force_point_geometry is set, reduce geometry to its centroid so downstream
         # point layers / gridding / .geometry.x|y keep working. Done per-geometry on

--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -723,11 +723,13 @@ def get_events(
         # The warehouse get_events accepts event type slugs directly, so pass the
         # values straight through — no value->id round-trip via get_event_types.
         #
-        # raw_details: the warehouse can also serve `event_details` as structured Arrow
-        # data, but only for a single event type (the struct is derived from that type's
-        # schema), and adopting it would mean refactoring the tasks and workflows that
-        # consume the column, which expect dicts. So ask for the raw JSON form — valid
-        # for any number of event types — and decode it to dicts below.
+        # event_details: the warehouse serves it as a structured Arrow struct, which
+        # `from_arrow` lands as dicts, but that struct is derived from one event type's
+        # schema and so requires a single-type selection. Workflows also allow zero or
+        # many types (download-events offers "leave empty for all event types"), so fall
+        # back to the raw JSON form there and decode it below — either way the column
+        # ends up dicts, as the ER API path serves it.
+        raw_details = include_details and len(event_types) != 1
         table = warehouse_client.get_events(
             since=time_range.since.isoformat(),
             until=time_range.until.isoformat(),
@@ -736,7 +738,7 @@ def get_events(
             include_details=include_details,
             include_updates=include_updates,
             include_related_events=include_related_events,
-            raw_details=include_details,
+            raw_details=raw_details,
         )
         events_df = gpd.GeoDataFrame.from_arrow(table).rename(
             columns={
@@ -745,7 +747,7 @@ def get_events(
                 "event_time": "time",
             }
         )
-        if include_details:
+        if raw_details:
             from ecoscope.io.earthranger_utils import decode_raw_event_details
 
             decode_raw_event_details(events_df)

--- a/tests/platform/tasks/test_io_earthranger_warehouse_events.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_events.py
@@ -41,13 +41,17 @@ def _make_events_arrow_table(
     event_category_values=("monitoring",),
     geometry_wkbs=None,
     event_times=None,
+    event_details=None,
 ):
     """Build a pa.Table matching EVENTS_SCHEMA_V1 with one row per event type.
 
     ``geometry_wkbs`` optionally overrides the default point geometry (one WKB per
     event type); useful for exercising polygon -> centroid reduction.
     ``event_times`` optionally overrides the per-row event_time (tz-aware datetimes);
-    useful for exercising sort-by-time parity."""
+    useful for exercising sort-by-time parity.
+    ``event_details`` optionally overrides the per-row event_details; these are raw
+    JSON strings, as the warehouse serves them with ``raw_details=True`` (the flat
+    ``EVENTS_SCHEMA_V1`` types the column ``pa.string()``)."""
     import datetime as dt
 
     import geoarrow.pyarrow as ga  # type: ignore[import-untyped]
@@ -85,7 +89,7 @@ def _make_events_arrow_table(
                 geometry_wkbs if geometry_wkbs is not None else [Point(36.8 + i, -1.3).wkb for i in range(n)]
             ),
             "reported_by": pa.array([{"id": "u1", "name": "Ranger", "type": "user"}] * n),
-            "event_details": [None] * n,
+            "event_details": list(event_details) if event_details is not None else [None] * n,
             "das_tenant_id": ["tenant-a"] * n,
         },
         schema=EVENTS_SCHEMA_V1,
@@ -393,6 +397,122 @@ def test_get_events_via_warehouse_client_event_columns_subset():
 
     assert sorted(result.columns) == sorted(["id", "time", "event_type", "geometry"])
     _assert_valid_events_gdf(result)
+
+
+@requires_dwh_events
+@pytest.mark.parametrize(
+    "event_types",
+    [[], ["hwc_rep"], ["hwc_rep", "fire_rep"]],
+    ids=["all-types", "one-type", "many-types"],
+)
+def test_get_events_via_warehouse_client_details_request_raw(event_types):
+    """include_details asks the warehouse for raw JSON details. The typed struct is
+    derived from a single event type's schema and so raises for the zero- and
+    many-type selections workflows allow (ERDW-276)."""
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_events.return_value = _make_events_arrow_table()
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        get_events(
+            client=mock_legacy_client,
+            time_range=_EVENT_TIME_RANGE,
+            event_types=event_types,
+            include_details=True,
+            raise_on_empty=False,
+        )
+
+    call_kwargs = mock_warehouse_client.get_events.call_args.kwargs
+    assert call_kwargs["include_details"] is True
+    assert call_kwargs["raw_details"] is True
+
+
+@requires_dwh_events
+def test_get_events_via_warehouse_client_no_details_does_not_request_raw():
+    """Without include_details there is no typed-struct constraint to work around, so
+    the request stays in the warehouse's omit mode."""
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_events.return_value = _make_events_arrow_table()
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        get_events(
+            client=mock_legacy_client,
+            time_range=_EVENT_TIME_RANGE,
+            event_types=["hwc_rep", "fire_rep"],
+            raise_on_empty=False,
+        )
+
+    call_kwargs = mock_warehouse_client.get_events.call_args.kwargs
+    assert call_kwargs["include_details"] is False
+    assert call_kwargs["raw_details"] is False
+
+
+@requires_dwh_events
+def test_get_events_via_warehouse_client_decodes_raw_details_to_dicts():
+    """The warehouse serves raw event_details as a JSON string; the task decodes it so
+    the column matches the ER API path, which every downstream consumer assumes --
+    process_events_details no-ops on non-dicts and normalize_json_column
+    (pd.json_normalize) cannot flatten strings."""
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_events.return_value = _make_events_arrow_table(
+        event_type_values=("hwc_rep", "fire_rep"),
+        event_category_values=("monitoring", "monitoring"),
+        event_details=['{"species": "elephant", "count": 3}', None],
+    )
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        result = get_events(
+            client=mock_legacy_client,
+            time_range=_EVENT_TIME_RANGE,
+            event_types=["hwc_rep", "fire_rep"],
+            include_details=True,
+            raise_on_empty=False,
+        )
+
+    # A detail-less event becomes {}, as the ER API serves it.
+    assert result["event_details"].tolist() == [{"species": "elephant", "count": 3}, {}]
+    _assert_valid_events_gdf(result)
+
+
+@requires_dwh_events
+def test_get_events_via_warehouse_client_details_normalize_into_columns():
+    """End-to-end contract the download-events and event-details workflows rely on:
+    the decoded details flatten into event_details__* columns."""
+    from ecoscope.platform.tasks.transformation import normalize_json_column
+
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_events.return_value = _make_events_arrow_table(
+        event_details=['{"species": "elephant", "count": 3}'],
+    )
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        result = get_events(
+            client=mock_legacy_client,
+            time_range=_EVENT_TIME_RANGE,
+            event_types=["hwc_rep"],
+            include_details=True,
+            raise_on_empty=False,
+        )
+
+    normalized = normalize_json_column(df=result, column="event_details", sort_columns=False)
+
+    assert normalized["event_details__species"].tolist() == ["elephant"]
+    assert normalized["event_details__count"].tolist() == [3]
 
 
 @requires_dwh_events

--- a/tests/platform/tasks/test_io_earthranger_warehouse_events.py
+++ b/tests/platform/tasks/test_io_earthranger_warehouse_events.py
@@ -42,6 +42,7 @@ def _make_events_arrow_table(
     geometry_wkbs=None,
     event_times=None,
     event_details=None,
+    details_type=None,
 ):
     """Build a pa.Table matching EVENTS_SCHEMA_V1 with one row per event type.
 
@@ -49,9 +50,11 @@ def _make_events_arrow_table(
     event type); useful for exercising polygon -> centroid reduction.
     ``event_times`` optionally overrides the per-row event_time (tz-aware datetimes);
     useful for exercising sort-by-time parity.
-    ``event_details`` optionally overrides the per-row event_details; these are raw
-    JSON strings, as the warehouse serves them with ``raw_details=True`` (the flat
-    ``EVENTS_SCHEMA_V1`` types the column ``pa.string()``)."""
+    ``event_details`` optionally overrides the per-row event_details. By default these
+    are raw JSON strings, as the warehouse serves them with ``raw_details=True`` (the
+    flat ``EVENTS_SCHEMA_V1`` types the column ``pa.string()``); pass ``details_type``
+    with a ``pa.struct`` to model typed mode instead, where the API swaps in a struct
+    derived from the single event type's schema and the values are dicts."""
     import datetime as dt
 
     import geoarrow.pyarrow as ga  # type: ignore[import-untyped]
@@ -68,6 +71,15 @@ def _make_events_arrow_table(
         return pa.array(
             [dt.datetime(2015, 6, 1, tzinfo=dt.timezone.utc)] * n,
             type=pa.timestamp("ns", tz="UTC"),
+        )
+
+    schema = EVENTS_SCHEMA_V1
+    if details_type is not None:
+        # Typed mode: the API replaces the flat schema's string event_details with the
+        # struct it derives from the event type's JSON-Schema.
+        schema = schema.set(
+            schema.get_field_index("event_details"),
+            pa.field("event_details", details_type),
         )
 
     return pa.table(
@@ -92,7 +104,7 @@ def _make_events_arrow_table(
             "event_details": list(event_details) if event_details is not None else [None] * n,
             "das_tenant_id": ["tenant-a"] * n,
         },
-        schema=EVENTS_SCHEMA_V1,
+        schema=schema,
     )
 
 
@@ -399,16 +411,34 @@ def test_get_events_via_warehouse_client_event_columns_subset():
     _assert_valid_events_gdf(result)
 
 
+def _details_struct():
+    """The typed event_details struct the API derives from one event type's JSON-Schema:
+    enum -> string, integer -> int64, date-time string stays string (no opt-in)."""
+    import pyarrow as pa
+
+    return pa.struct(
+        [
+            ("species", pa.string()),
+            ("count", pa.int64()),
+            ("notes", pa.string()),
+        ]
+    )
+
+
 @requires_dwh_events
 @pytest.mark.parametrize(
-    "event_types",
-    [[], ["hwc_rep"], ["hwc_rep", "fire_rep"]],
+    "event_types, expect_raw",
+    [
+        ([], True),
+        (["hwc_rep"], False),
+        (["hwc_rep", "fire_rep"], True),
+    ],
     ids=["all-types", "one-type", "many-types"],
 )
-def test_get_events_via_warehouse_client_details_request_raw(event_types):
-    """include_details asks the warehouse for raw JSON details. The typed struct is
-    derived from a single event type's schema and so raises for the zero- and
-    many-type selections workflows allow (ERDW-276)."""
+def test_get_events_via_warehouse_client_details_mode_by_type_count(event_types, expect_raw):
+    """A single event type gets the typed struct; zero or many types fall back to raw
+    JSON, since the struct is derived from one event type's schema and the warehouse
+    rejects it otherwise (ERDW-276)."""
     mock_legacy_client = MagicMock()
     mock_warehouse_client = MagicMock()
     mock_warehouse_client.get_events.return_value = _make_events_arrow_table()
@@ -427,13 +457,19 @@ def test_get_events_via_warehouse_client_details_request_raw(event_types):
 
     call_kwargs = mock_warehouse_client.get_events.call_args.kwargs
     assert call_kwargs["include_details"] is True
-    assert call_kwargs["raw_details"] is True
+    assert call_kwargs["raw_details"] is expect_raw
 
 
 @requires_dwh_events
-def test_get_events_via_warehouse_client_no_details_does_not_request_raw():
-    """Without include_details there is no typed-struct constraint to work around, so
-    the request stays in the warehouse's omit mode."""
+@pytest.mark.parametrize(
+    "event_types",
+    [[], ["hwc_rep"], ["hwc_rep", "fire_rep"]],
+    ids=["all-types", "one-type", "many-types"],
+)
+def test_get_events_via_warehouse_client_no_details_stays_in_omit_mode(event_types):
+    """Without include_details there are no details to shape, so the request stays in
+    the warehouse's omit mode for every selection -- raw_details would turn details
+    back on (the io-core client sends include_details=want_typed or raw_details)."""
     mock_legacy_client = MagicMock()
     mock_warehouse_client = MagicMock()
     mock_warehouse_client.get_events.return_value = _make_events_arrow_table()
@@ -445,7 +481,7 @@ def test_get_events_via_warehouse_client_no_details_does_not_request_raw():
         get_events(
             client=mock_legacy_client,
             time_range=_EVENT_TIME_RANGE,
-            event_types=["hwc_rep", "fire_rep"],
+            event_types=event_types,
             raise_on_empty=False,
         )
 
@@ -456,10 +492,10 @@ def test_get_events_via_warehouse_client_no_details_does_not_request_raw():
 
 @requires_dwh_events
 def test_get_events_via_warehouse_client_decodes_raw_details_to_dicts():
-    """The warehouse serves raw event_details as a JSON string; the task decodes it so
-    the column matches the ER API path, which every downstream consumer assumes --
+    """Multi-type selections get raw event_details as a JSON string; the task decodes it
+    so the column matches the ER API path, which every downstream consumer assumes --
     process_events_details no-ops on non-dicts and normalize_json_column
-    (pd.json_normalize) cannot flatten strings."""
+    (pd.json_normalize) silently yields no columns for strings."""
     mock_legacy_client = MagicMock()
     mock_warehouse_client = MagicMock()
     mock_warehouse_client.get_events.return_value = _make_events_arrow_table(
@@ -486,15 +522,17 @@ def test_get_events_via_warehouse_client_decodes_raw_details_to_dicts():
 
 
 @requires_dwh_events
-def test_get_events_via_warehouse_client_details_normalize_into_columns():
-    """End-to-end contract the download-events and event-details workflows rely on:
-    the decoded details flatten into event_details__* columns."""
-    from ecoscope.platform.tasks.transformation import normalize_json_column
-
+def test_get_events_via_warehouse_client_typed_details_arrive_as_dicts():
+    """Single-type selections get the typed struct, which from_arrow lands as dicts --
+    so no decode is needed and none is applied: absent schema fields stay None (rather
+    than being dropped) and a detail-less event stays a whole-cell None."""
     mock_legacy_client = MagicMock()
     mock_warehouse_client = MagicMock()
     mock_warehouse_client.get_events.return_value = _make_events_arrow_table(
-        event_details=['{"species": "elephant", "count": 3}'],
+        event_type_values=("hwc_rep", "hwc_rep"),
+        event_category_values=("monitoring", "monitoring"),
+        event_details=[{"species": "elephant", "count": 3}, None],
+        details_type=_details_struct(),
     )
 
     with patch(
@@ -505,6 +543,48 @@ def test_get_events_via_warehouse_client_details_normalize_into_columns():
             client=mock_legacy_client,
             time_range=_EVENT_TIME_RANGE,
             event_types=["hwc_rep"],
+            include_details=True,
+            raise_on_empty=False,
+        )
+
+    assert mock_warehouse_client.get_events.call_args.kwargs["raw_details"] is False
+    # `notes` is absent from the data but present in the struct -> padded in as None.
+    assert result["event_details"].tolist() == [
+        {"species": "elephant", "count": 3, "notes": None},
+        None,
+    ]
+    _assert_valid_events_gdf(result)
+
+
+@requires_dwh_events
+@pytest.mark.parametrize("mode", ["typed", "raw"])
+def test_get_events_via_warehouse_client_details_normalize_into_columns(mode):
+    """End-to-end contract the download-events and event-details workflows rely on: in
+    either mode the details flatten into event_details__* columns."""
+    from ecoscope.platform.tasks.transformation import normalize_json_column
+
+    if mode == "typed":
+        table = _make_events_arrow_table(
+            event_details=[{"species": "elephant", "count": 3}],
+            details_type=_details_struct(),
+        )
+    else:
+        table = _make_events_arrow_table(event_details=['{"species": "elephant", "count": 3}'])
+
+    mock_legacy_client = MagicMock()
+    mock_warehouse_client = MagicMock()
+    mock_warehouse_client.get_events.return_value = table
+
+    with patch(
+        "ecoscope.platform.tasks.io._earthranger._make_warehouse_client_from_env",
+        return_value=mock_warehouse_client,
+    ):
+        result = get_events(
+            client=mock_legacy_client,
+            time_range=_EVENT_TIME_RANGE,
+            # one type for typed; two would flip the request to raw, but the mock
+            # returns the table under test either way
+            event_types=["hwc_rep"] if mode == "typed" else ["hwc_rep", "fire_rep"],
             include_details=True,
             raise_on_empty=False,
         )

--- a/tests/test_earthranger_utils.py
+++ b/tests/test_earthranger_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ecoscope.io.earthranger_utils import normalize_column
+from ecoscope.io.earthranger_utils import decode_raw_event_details, normalize_column
 from ecoscope.io.utils import clean_time_cols
 
 
@@ -116,3 +116,80 @@ def test_normalize_column_sorted():
     # Verify column order: original columns first, then alphabetically sorted new columns
     expected_column_order = original_cols + expected_new_cols
     assert list(df_with_nested_column.columns) == expected_column_order
+
+
+def test_decode_raw_event_details():
+    df = pd.DataFrame(
+        {
+            "id": ["e1", "e2"],
+            "event_details": [
+                '{"species": "elephant", "count": 3}',
+                '{"nested": {"a": 1}, "list": [1, 2]}',
+            ],
+        }
+    )
+
+    decode_raw_event_details(df)
+
+    assert df["event_details"].tolist() == [
+        {"species": "elephant", "count": 3},
+        {"nested": {"a": 1}, "list": [1, 2]},
+    ]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", pd.NA, np.nan],
+    ids=["none", "empty-string", "pd-NA", "nan"],
+)
+def test_decode_raw_event_details_null_becomes_empty_dict(value):
+    """Parity with the ER API, which serves `event_details: {}` for an event without
+    details, and a precondition for pd.json_normalize (which rejects non-dicts)."""
+    df = pd.DataFrame({"event_details": [value, '{"a": 1}']})
+
+    decode_raw_event_details(df)
+
+    assert df["event_details"].tolist() == [{}, {"a": 1}]
+
+
+@pytest.mark.parametrize("value", ["not json at all", "[1, 2]", "42", '"a string"'])
+def test_decode_raw_event_details_unusable_payload_becomes_empty_dict(value):
+    """One malformed (or non-object) payload must not fail the whole download."""
+    df = pd.DataFrame({"event_details": [value, '{"a": 1}']})
+
+    decode_raw_event_details(df)
+
+    assert df["event_details"].tolist() == [{}, {"a": 1}]
+
+
+def test_decode_raw_event_details_is_idempotent():
+    df = pd.DataFrame({"event_details": ['{"a": 1}']})
+
+    decode_raw_event_details(df)
+    decode_raw_event_details(df)
+
+    assert df["event_details"].tolist() == [{"a": 1}]
+
+
+def test_decode_raw_event_details_missing_column_is_a_noop():
+    df = pd.DataFrame({"id": ["e1"]})
+
+    decode_raw_event_details(df)
+
+    assert list(df.columns) == ["id"]
+
+
+def test_decode_raw_event_details_feeds_normalize_column():
+    """The end-to-end contract the download-events workflow relies on: decoded details
+    flatten into `event_details__*` columns."""
+    df = pd.DataFrame(
+        {
+            "id": ["e1", "e2"],
+            "event_details": ['{"species": "elephant"}', None],
+        }
+    )
+
+    decode_raw_event_details(df)
+    normalize_column(df, "event_details")
+
+    assert df["event_details__species"].tolist() == ["elephant", np.nan]


### PR DESCRIPTION
## :earth_americas: Summary
Closes #822 

## :package: Proposed Changes
The DWH returns typed `event_details` as an Arrow struct by default, which requires exactly one event type, so `get_events` raised whenever  `include_details` was set with zero or many types, breaking the  `download-events` workflow.

The task now picks the mode by selection count: the typed struct for a single  event type (`from_arrow` lands it as dicts), and the raw JSON form, decoded to  dicts, for zero or many. Either way the column matches what the ER API path serves, so no workflow changes are needed.


## 📋 Checklist
