### PR TITLE
Skip overwrite on content hashed persistence tasks

### DIFF
--- a/ecoscope/platform/serde.py
+++ b/ecoscope/platform/serde.py
@@ -65,6 +65,33 @@ def _get_path(root_path: str, filename: str):
     return write_path, read_path
 
 
+def _read_path_if_file_exists(root_path: str, filename: str) -> str | None:
+    """The read path for `filename` under `root_path`, if it is already a usable file.
+
+    Lets a caller skip a redundant write and still hand back the same path
+    `_persist_text` / `_persist_bytes` would have returned. Only safe for callers
+    whose `filename` fully determines the content (content-addressed / hash-derived
+    names), since the existing bytes stand in for the ones not written.
+
+    None when the target is absent, is not a regular file, or is an empty local
+    file (the usual artifact of a crash mid-write; local writes are not atomic,
+    GCS uploads are).
+
+    `is_file()` rather than `exists()`: on GS a bare prefix match reports as
+    existing, and locally a directory would too -- which would silently skip a
+    write that should raise.
+
+    Note: as with `_get_path`, resolving a local `root_path` creates the directory
+    as a side effect.
+    """
+    write_path, read_path = _get_path(root_path, filename)
+    if not write_path.is_file():
+        return None
+    if isinstance(write_path, Path) and write_path.stat().st_size == 0:
+        return None
+    return read_path
+
+
 def _persist_text(text: str, root_path: str, filename: str) -> str:
     write_path, read_path = _get_path(root_path, filename)
 

--- a/ecoscope/platform/serde.py
+++ b/ecoscope/platform/serde.py
@@ -66,20 +66,9 @@ def _get_path(root_path: str, filename: str):
 
 
 def _read_path_if_file_exists(root_path: str, filename: str) -> str | None:
-    """The read path for `filename` under `root_path`, if it is already a usable file.
+    """Return the read path for `filename` under `root_path`, if it already exists and is a usable file.
 
-    Lets a caller skip a redundant write and still hand back the same path
-    `_persist_text` / `_persist_bytes` would have returned. Only safe for callers
-    whose `filename` fully determines the content (content-addressed / hash-derived
-    names), since the existing bytes stand in for the ones not written.
-
-    None when the target is absent, is not a regular file, or is an empty local
-    file (the usual artifact of a crash mid-write; local writes are not atomic,
-    GCS uploads are).
-
-    `is_file()` rather than `exists()`: on GS a bare prefix match reports as
-    existing, and locally a directory would too -- which would silently skip a
-    write that should raise.
+    Returns None when the target is absent, is not a regular file, or is an empty local file.
 
     Note: as with `_get_path`, resolving a local `root_path` creates the directory
     as a side effect.

--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -24,7 +24,7 @@ from ecoscope.platform.schemas import (
     SpatialFeaturesGroup,
     SubjectGroupObservationsGDF,
 )
-from ecoscope.platform.serde import _persist_bytes
+from ecoscope.platform.serde import _persist_bytes, _read_path_if_file_exists
 from ecoscope.platform.tasks.filter._filter import TimeRange
 from ecoscope.platform.tasks.io._persist import (
     _fallback_to_empty_grouped,
@@ -1253,6 +1253,9 @@ def download_grouped_event_attachments(
     `split_groups` — and writes each event's files to
     `output_dir/<attachments_subdir>/<key_hash>_<event_id>/<filename>`.
 
+    A file already present at the target path is left alone: it is neither
+    refetched nor rewritten.
+
     `<key_hash>` is a short sha256 hash of the encoded group key, computed
     by the same helper used by `persist_grouped_dfs_for_results_download`,
     so the FE can match downloaded attachments to the dashboard view they
@@ -1310,12 +1313,18 @@ def download_grouped_event_attachments(
                 filename = result["filename"]
                 basename = Path(filename).name
 
-                response = client._get(  # type: ignore[attr-defined]
-                    f"activity/event/{event_id}/file/{file_id}/original/{filename}",
-                    return_response=True,
-                )
+                # Each event has its own folder, so a name clash here means a
+                # second attachment on this event sharing a filename. Keep the
+                # first: overwriting it would fail anyway on a `gs://` root,
+                # where replacing an object needs a delete permission the
+                # workflow service account does not have.
+                if _read_path_if_file_exists(event_dir, basename) is None:
+                    response = client._get(  # type: ignore[attr-defined]
+                        f"activity/event/{event_id}/file/{file_id}/original/{filename}",
+                        return_response=True,
+                    )
 
-                _persist_bytes(response.content, event_dir, basename)
+                    _persist_bytes(response.content, event_dir, basename)
 
                 downloaded_paths.append(f"{attachments_subdir}/{event_dir_name}/{basename}")
 

--- a/ecoscope/platform/tasks/io/_earthranger.py
+++ b/ecoscope/platform/tasks/io/_earthranger.py
@@ -1314,10 +1314,9 @@ def download_grouped_event_attachments(
                 basename = Path(filename).name
 
                 # Each event has its own folder, so a name clash here means a
-                # second attachment on this event sharing a filename. Keep the
-                # first: overwriting it would fail anyway on a `gs://` root,
-                # where replacing an object needs a delete permission the
-                # workflow service account does not have.
+                # second attachment on this event sharing a filename.
+                # Shouldn't be possible due to upstream conventions, but
+                # handling defensively here by skipping the duplicated write.
                 if _read_path_if_file_exists(event_dir, basename) is None:
                     response = client._get(  # type: ignore[attr-defined]
                         f"activity/event/{event_id}/file/{file_id}/original/{filename}",

--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -123,10 +123,15 @@ ResultsFileType = Literal["csv", "gpkg", "geoparquet", "parquet"]
 def _hash_df(df: AnyDataFrame) -> str:
     """Return a 7-char sha256 hash of a dataframe's contents.
 
-    Covers every row and the index, plus column names and dtypes, so the hash
-    fully determines the bytes any given filetype will serialize. Shared by
-    `persist_df`, `persist_df_wrapper` and `persist_geoarrow_for_pydeck` so all
-    three derive identical content-based filenames.
+    Covers every row and the index, plus column names and dtypes, so equal
+    frames hash equally and unequal frames don't. Shared by `persist_df`,
+    `persist_df_wrapper` and `persist_geoarrow_for_pydeck`.
+
+    It identifies the *content*, not the bytes on disk: the same frame encoded
+    two ways hashes the same. A caller that skips writing an existing target
+    therefore owes the rest of the name — extension is usually enough, but
+    `persist_geoarrow_for_pydeck` also needs `GEOARROW_FILENAME_PREFIX`, since
+    its geoarrow parquet would otherwise collide with `persist_df`'s WKB one.
     """
     import numpy as np
     import pandas as pd

--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -143,7 +143,14 @@ def _hash_df(df: AnyDataFrame) -> str:
             # Cells pandas can't hash (lists/dicts in event details). `repr`
             # rather than `str`: in a mixed column `str` collapses 1 and "1"
             # to the same text, and a filename collision serves wrong bytes.
-            return pd.util.hash_pandas_object(obj.map(repr), index=False).values
+            try:
+                return pd.util.hash_pandas_object(obj.map(repr), index=False).values
+            except Exception as e:
+                # Fail loudly if we hit a value whose own `__repr__` fails.
+                label = obj.name if isinstance(obj, pd.Series) else "<index>"
+                raise TypeError(
+                    f"cannot content-hash column {label!r}: values are neither hashable nor reprable"
+                ) from e
 
     digest = hashlib.sha256()
     try:

--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -370,8 +370,14 @@ def persist_df_wrapper(
             geom_name = df.geometry.name
             attrs = df.drop(columns=[geom_name])
             attrs = cast(gpd.GeoDataFrame, sanitize_for_arrow(attrs))
-            # let geopandas handle geometry encoding
-            df_new = cast(AnyDataFrame, attrs.join(df[[geom_name]]))
+            # Reattach geometry positionally rather than via `.join`.
+            # which aligns on the index, and creates duplication in
+            # cases where frames carry non-unique indexes
+            attrs[geom_name] = df[geom_name].to_numpy()
+            df_new = cast(
+                AnyDataFrame,
+                gpd.GeoDataFrame(attrs, geometry=geom_name, crs=df.geometry.crs),
+            )
         else:
             df_new = cast(AnyDataFrame, sanitize_for_arrow(df))
     else:

--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -186,11 +186,28 @@ def _filetype_extension(filetype: FileType) -> str:
         case "csv" | "gpkg" | "geojson" | "json":
             return filetype
         case "geoparquet" | "parquet":
-            # Deliberately shared: for a frame with geometry both branches below
-            # emit identical bytes.
+            # Deliberately shared: `_require_geometry` below rejects the one case
+            # where the two branches diverge, so whenever both are reachable for a
+            # given frame they emit identical bytes.
             return "parquet"
         case _:
             raise NotImplementedError(f"Unsupported file type: {filetype}")
+
+
+def _has_geometry(df: AnyDataFrame) -> bool:
+    """Whether `df` carries at least one geometry-dtype column."""
+    import geopandas as gpd  # type: ignore[import-untyped]
+
+    return any(isinstance(dtype, gpd.array.GeometryDtype) for dtype in df.dtypes)
+
+
+def _require_geometry(df: AnyDataFrame, filetype: FileType) -> None:
+    """Raise unless `df` has geometry, for filetypes that cannot encode without it."""
+    if not _has_geometry(df):
+        raise ValueError(
+            f"filetype {filetype!r} requires at least one geometry column, "
+            f"but none of the {len(df.columns)} column(s) has geometry dtype"
+        )
 
 
 def _persist_df(
@@ -216,6 +233,9 @@ def _persist_df(
         filename = _hash_df(df)
     target = f"{filename}.{_filetype_extension(filetype)}"
 
+    if filetype == "geoparquet":
+        _require_geometry(df, filetype)
+
     if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:
         return existing
 
@@ -236,8 +256,7 @@ def _persist_df(
             return _persist_bytes(buffer.getvalue(), root_path, target)
         case "parquet":
             buffer = io.BytesIO()
-            has_geom = any(isinstance(df[col].dtype, gpd.array.GeometryDtype) for col in df.columns)
-            if has_geom:
+            if _has_geometry(df):
                 gpd.GeoDataFrame(df).to_parquet(buffer, index=False)
             else:
                 df.to_parquet(buffer, index=False)

--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -11,7 +11,7 @@ from wt_task.skip import SkippedDependencyFallback, SkipSentinel
 
 from ecoscope.platform.annotations import AdvancedField, AnyDataFrame
 from ecoscope.platform.indexes import CompositeFilter
-from ecoscope.platform.serde import _persist_bytes, _persist_text
+from ecoscope.platform.serde import _persist_bytes, _persist_text, _read_path_if_file_exists
 from ecoscope.platform.tasks.transformation._sanitize import sanitize_for_arrow
 
 
@@ -43,8 +43,13 @@ def persist_text(
         ),
     ] = None,
 ) -> Annotated[str, Field(description="Path to persisted text")]:
-    """Persist text to a file or cloud storage object."""
+    """Persist text to a file or cloud storage object.
 
+    When the filename is generated from a hash of the text, a target that
+    already exists is returned as-is rather than rewritten.
+    """
+
+    content_addressed = not filename
     if not filename:
         # generate a filename if none is explicitly provided
         filename = hashlib.sha256(text.encode()).hexdigest()[:7] + ".html"
@@ -52,6 +57,8 @@ def persist_text(
         filepath = Path(filename)
         filename = f"{filepath.stem}_{filename_suffix}{filepath.suffix}"
 
+    if content_addressed and (existing := _read_path_if_file_exists(root_path, filename)) is not None:
+        return existing
     return _persist_text(text, root_path, filename)
 
 
@@ -81,12 +88,17 @@ def persist_json(
         ),
     ] = None,
 ) -> Annotated[str, Field(description="Path to persisted JSON")]:
-    """Serialize JSON-shaped data and persist to a file or cloud storage object."""
+    """Serialize JSON-shaped data and persist to a file or cloud storage object.
+
+    When the filename is generated from a hash of the payload, a target that
+    already exists is returned as-is rather than rewritten.
+    """
     if isinstance(data, BaseModel):
         payload = data.model_dump_json()
     else:
         payload = json.dumps(data)
 
+    content_addressed = not filename
     if not filename:
         filename = hashlib.sha256(payload.encode()).hexdigest()[:7] + ".json"
     elif not Path(filename).suffix:
@@ -95,6 +107,8 @@ def persist_json(
         filepath = Path(filename)
         filename = f"{filepath.stem}_{filename_suffix}{filepath.suffix}"
 
+    if content_addressed and (existing := _read_path_if_file_exists(root_path, filename)) is not None:
+        return existing
     return _persist_text(payload, root_path, filename)
 
 
@@ -109,26 +123,34 @@ ResultsFileType = Literal["csv", "gpkg", "geoparquet", "parquet"]
 def _hash_df(df: AnyDataFrame) -> str:
     """Return a 7-char sha256 hash of a dataframe's contents.
 
-    Falls back to hashing the shape + first rows when the frame holds unhashable
-    values. Shared by `persist_df` and `persist_df_wrapper` so both derive
-    identical content-based filenames.
+    Covers every row and the index, plus column names and dtypes, so the hash
+    fully determines the bytes any given filetype will serialize. Shared by
+    `persist_df`, `persist_df_wrapper` and `persist_geoarrow_for_pydeck` so all
+    three derive identical content-based filenames.
     """
     import numpy as np
     import pandas as pd
 
-    # Use a hash of the dataframe content; avoids issues with unhashable types.
+    def _fallback_hash(obj):
+        try:
+            return pd.util.hash_pandas_object(obj, index=False).values
+        except (TypeError, ValueError, AttributeError):
+            # Cells pandas can't hash (lists/dicts in event details). `repr`
+            # rather than `str`: in a mixed column `str` collapses 1 and "1"
+            # to the same text, and a filename collision serves wrong bytes.
+            return pd.util.hash_pandas_object(obj.map(repr), index=False).values
+
+    digest = hashlib.sha256()
     try:
-        hash_values = pd.util.hash_pandas_object(df).values
-        # Convert to bytes - handle both ndarray and ExtensionArray
-        if isinstance(hash_values, np.ndarray):
-            hash_input = hash_values.tobytes()
-        else:
-            hash_input = np.asarray(hash_values).tobytes()
+        digest.update(np.ascontiguousarray(pd.util.hash_pandas_object(df).values))
     except (TypeError, ValueError, AttributeError):
-        # Fallback for unhashable types: use shape and first few rows
-        content = f"{df.shape}{df.head(5).to_dict()}"
-        hash_input = content.encode()
-    return hashlib.sha256(hash_input).hexdigest()[:7]
+        # Only now, and only for the columns that genuinely fail, pay per-column
+        # costs. Every row still contributes; hashing a `head(5)` sample here
+        # let two frames sharing shape and first rows collide.
+        for obj in (df.index, *(df.iloc[:, i] for i in range(len(df.columns)))):
+            digest.update(np.ascontiguousarray(_fallback_hash(obj)))
+    digest.update(json.dumps([[str(c), str(dt)] for c, dt in zip(df.columns, df.dtypes)]).encode())
+    return digest.hexdigest()[:7]
 
 
 @register()
@@ -146,41 +168,87 @@ def persist_df(
     ] = None,
     filetype: Annotated[FileType, Field(description="The output format")] = "csv",
 ) -> Annotated[str, Field(description="Path to persisted data")]:
-    """Persist dataframe to a file or cloud storage object."""
+    """Persist dataframe to a file or cloud storage object.
+
+    When the filename is generated from the df content hash, a target that
+    already exists is returned as-is rather than serialized and rewritten.
+    """
+    return _persist_df(df, root_path, filename, filetype, content_addressed=not filename)
+
+
+def _filetype_extension(filetype: FileType) -> str:
+    """On-disk extension for `filetype`.
+
+    Resolved before serializing so the target name is known up front, which is
+    what lets `_persist_df` skip the encode as well as the write.
+    """
+    match filetype:
+        case "csv" | "gpkg" | "geojson" | "json":
+            return filetype
+        case "geoparquet" | "parquet":
+            # Deliberately shared: for a frame with geometry both branches below
+            # emit identical bytes.
+            return "parquet"
+        case _:
+            raise NotImplementedError(f"Unsupported file type: {filetype}")
+
+
+def _persist_df(
+    df: AnyDataFrame,
+    root_path: str,
+    filename: str | None,
+    filetype: FileType,
+    *,
+    content_addressed: bool,
+) -> str:
+    """Implementation behind `persist_df`, with the skip-if-exists policy exposed.
+
+    `content_addressed` must only be True when `filename` is derived from a hash
+    of `df`, because it lets an existing target stand in for the write. Kept
+    private and keyword-only so the registered `persist_df` signature stays the
+    whole public contract, and so no spec can pair an explicit filename with a
+    skip.
+    """
     import geopandas as gpd  # type: ignore[import-untyped]
 
     if not filename:
         # generate a filename if none is explicitly provided
         filename = _hash_df(df)
-    if filetype == "csv":
-        csv_buffer = io.StringIO()
-        df.to_csv(csv_buffer)
-        return _persist_text(csv_buffer.getvalue(), root_path, f"{filename}.{filetype}")
-    elif filetype == "gpkg":
-        buffer = io.BytesIO()
-        gdf = gpd.GeoDataFrame(df)
-        gdf.to_file(buffer, driver="GPKG")
-        return _persist_bytes(buffer.getvalue(), root_path, f"{filename}.{filetype}")
-    elif filetype == "geoparquet":
-        buffer = io.BytesIO()
-        gdf = gpd.GeoDataFrame(df)
-        gdf.to_parquet(buffer, index=False)
-        return _persist_bytes(buffer.getvalue(), root_path, f"{filename}.parquet")
-    elif filetype == "parquet":
-        buffer = io.BytesIO()
-        has_geom = any(isinstance(df[col].dtype, gpd.array.GeometryDtype) for col in df.columns)
-        if has_geom:
-            gpd.GeoDataFrame(df).to_parquet(buffer, index=False)
-        else:
-            df.to_parquet(buffer, index=False)
-        return _persist_bytes(buffer.getvalue(), root_path, f"{filename}.parquet")
-    elif filetype == "geojson":
-        gdf = gpd.GeoDataFrame(df)
-        return _persist_text(gdf.to_json(), root_path, f"{filename}.{filetype}")
-    elif filetype == "json":
-        return _persist_text(df.to_json(), root_path, f"{filename}.{filetype}")
-    else:
-        raise ValueError(f"Unsupported file type: {filetype}")
+    target = f"{filename}.{_filetype_extension(filetype)}"
+
+    if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:
+        return existing
+
+    match filetype:
+        case "csv":
+            csv_buffer = io.StringIO()
+            df.to_csv(csv_buffer)
+            return _persist_text(csv_buffer.getvalue(), root_path, target)
+        case "gpkg":
+            buffer = io.BytesIO()
+            gdf = gpd.GeoDataFrame(df)
+            gdf.to_file(buffer, driver="GPKG")
+            return _persist_bytes(buffer.getvalue(), root_path, target)
+        case "geoparquet":
+            buffer = io.BytesIO()
+            gdf = gpd.GeoDataFrame(df)
+            gdf.to_parquet(buffer, index=False)
+            return _persist_bytes(buffer.getvalue(), root_path, target)
+        case "parquet":
+            buffer = io.BytesIO()
+            has_geom = any(isinstance(df[col].dtype, gpd.array.GeometryDtype) for col in df.columns)
+            if has_geom:
+                gpd.GeoDataFrame(df).to_parquet(buffer, index=False)
+            else:
+                df.to_parquet(buffer, index=False)
+            return _persist_bytes(buffer.getvalue(), root_path, target)
+        case "geojson":
+            gdf = gpd.GeoDataFrame(df)
+            return _persist_text(gdf.to_json(), root_path, target)
+        case "json":
+            return _persist_text(df.to_json(), root_path, target)
+        case _:
+            raise NotImplementedError(f"Unsupported file type: {filetype}")
 
 
 def _fallback_to_empty(df: AnyDataFrame | SkipSentinel) -> AnyDataFrame:
@@ -198,17 +266,6 @@ def persist_df_wrapper(
         SkippedDependencyFallback(_fallback_to_empty),
     ],
     root_path: Annotated[str, Field(description="Root path to persist text to")],
-    filename: Annotated[
-        str | SkipJsonSchema[None],
-        Field(
-            description="""\
-            Optional filename to persist text to within the `root_path`.
-            If not provided, a filename will be generated based on a hash of the df content.
-            """,
-            default=None,
-            exclude=True,
-        ),
-    ] = None,
     filetypes: Annotated[
         list[ResultsFileType] | SkipJsonSchema[None],
         Field(
@@ -243,9 +300,12 @@ def persist_df_wrapper(
 
     Builds on `persist_df` by adding optional data sanitization (for Arrow-based
     formats like Parquet/GeoParquet), multi-filetype output, and a
-    `SkippedDependencyFallback`. When sanitize=True, complex Python objects
-    (lists, dicts, sets) are converted to JSON strings, data types are
-    normalized, and mixed-type columns are handled.
+    `SkippedDependencyFallback`. Filenames are always derived from a hash of the
+    (post-sanitization) content, so a target that already exists is returned
+    as-is rather than reserialized and rewritten.
+
+    When sanitize=True, complex Python objects (lists, dicts, sets) are converted
+    to JSON strings, data types are normalized, and mixed-type columns are handled.
 
     The sanitization process:
     - Converts bytes to UTF-8 strings
@@ -257,7 +317,6 @@ def persist_df_wrapper(
     Args:
         df: DataFrame or GeoDataFrame to save
         root_path: Directory where the file will be saved
-        filename: Optional filename (without path). If None, generates hash-based name.
         filetypes: A list of output formats - "csv", "gpkg", "geoparquet", or "parquet"
         sanitize: Whether to sanitize data for Arrow compatibility (default: False)
 
@@ -274,7 +333,6 @@ def persist_df_wrapper(
         >>> path = persist_df_wrapper(
         ...     df=df,
         ...     root_path="/output",
-        ...     filename="data.csv",
         ...     filetypes=["csv"],
         ...     sanitize=True  # Converts lists/dicts to JSON strings
         ... )
@@ -295,16 +353,16 @@ def persist_df_wrapper(
     else:
         df_new = df
 
-    filehash = _hash_df(df)
+    filehash = _hash_df(df_new)
     filename = f"{filename_prefix}_{filehash}" if filename_prefix else filehash
 
-    paths = [persist_df(df_new, root_path, filename, filetype) for filetype in filetypes]
+    paths = [_persist_df(df_new, root_path, filename, filetype, content_addressed=True) for filetype in filetypes]
 
     return paths
 
 
 def _hash_grouper_key(composite_filter: CompositeFilter) -> str:
-    """Return a 7-char sha256 hash of the JSON-encoded grouper key.
+    """Return a 6-char sha256 hash of the JSON-encoded grouper key.
 
     The CompositeFilter is first reduced to a `{column: value}` dict, e.g.
     `(("patrol_type", "=", "Routine Patrol"),)` -> `{"patrol_type": "Routine Patrol"}`,
@@ -331,7 +389,7 @@ def persist_grouped_dfs_for_results_download(
         Field(
             description=(
                 "A keyed iterable of (group key, dataframe) tuples as produced by `split_groups`. "
-                "Each dataframe is persisted to its own file(s) with a 7-char "
+                "Each dataframe is persisted to its own file(s) with a 6-char "
                 "hash of the associated group key embedded in the filename."
             ),
         ),
@@ -373,13 +431,16 @@ def persist_grouped_dfs_for_results_download(
     """Persist grouped or ungrouped dataframes for FE results-download.
 
     Delegates to `persist_df_wrapper` per dataframe, prefixing the filename
-    with a 7-char sha256 hash of the encoded group key so the FE can match
+    with a 6-char sha256 hash of the encoded group key so the FE can match
     files to dashboard views. Final filename layout:
 
         [<filename_prefix>_]<key_hash>_<df_hash>.<extension>
 
     Each group's own CompositeFilter is hashed. Groups with a `None` key (e.g.
     the SkippedDependencyFallback sentinel) or an empty dataframe are skipped.
+
+    Inherits `persist_df_wrapper`'s content-addressed naming: a file that already
+    exists at the target path is returned as-is rather than rewritten.
     """
     paths: list[str] = []
     for composite_filter, df in grouped_dfs:

--- a/ecoscope/platform/tasks/results/_map_utils.py
+++ b/ecoscope/platform/tasks/results/_map_utils.py
@@ -310,7 +310,7 @@ def persist_geoarrow_for_pydeck(
 
     content_addressed = not filename
     if content_addressed:
-        filename = f"{_hash_df(gdf)}"
+        filename = f"{_hash_df(gdf)}"  # type: ignore[arg-type] mypy doesn't see that `AnyGeoDataFrame` is a subset of `AnyDataFrame`
     target = f"{filename}.parquet"
 
     if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:

--- a/ecoscope/platform/tasks/results/_map_utils.py
+++ b/ecoscope/platform/tasks/results/_map_utils.py
@@ -13,6 +13,7 @@ from wt_registry import register
 
 from ecoscope.platform.annotations import AdvancedField, AnyGeoDataFrame
 from ecoscope.platform.serde import _persist_bytes, _read_path_if_file_exists
+from ecoscope.platform.tasks.io._persist import _hash_df
 
 OpacityAnnotation = Annotated[
     float,
@@ -309,15 +310,7 @@ def persist_geoarrow_for_pydeck(
 
     content_addressed = not filename
     if content_addressed:
-        # Local import: keeps `results` from pulling in `io/__init__` (and
-        # `_earthranger`) at import time, matching this module's lazy-import style.
-        from ecoscope.platform.tasks.io._persist import _hash_df
-
-        # `_geoarrow` qualifier: `persist_df(filetype="geoparquet")` derives its
-        # name from the same `_hash_df` but writes WKB, not geoarrow. Without the
-        # qualifier both target `<hash>.parquet` and the skip below would hand
-        # back one encoding in place of the other.
-        filename = f"{_hash_df(gdf)}_geoarrow"
+        filename = f"{_hash_df(gdf)}"
     target = f"{filename}.parquet"
 
     if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:

--- a/ecoscope/platform/tasks/results/_map_utils.py
+++ b/ecoscope/platform/tasks/results/_map_utils.py
@@ -310,7 +310,7 @@ def persist_geoarrow_for_pydeck(
 
     content_addressed = not filename
     if content_addressed:
-        filename = f"{_hash_df(gdf)}"  # type: ignore[arg-type] mypy doesn't see that `AnyGeoDataFrame` is a subset of `AnyDataFrame`
+        filename = f"{_hash_df(gdf)}"  # type: ignore[arg-type] # mypy doesn't see that `AnyGeoDataFrame` is a subset of `AnyDataFrame`
     target = f"{filename}.parquet"
 
     if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:

--- a/ecoscope/platform/tasks/results/_map_utils.py
+++ b/ecoscope/platform/tasks/results/_map_utils.py
@@ -281,6 +281,15 @@ def _stringify_mixed_json(df):
             df[col] = df[col].map(lambda v: None if v is None else json.dumps(v, default=str))
 
 
+# Prefixed onto generated (content-addressed) geoarrow filenames.
+#
+# `_hash_df` is shared with `tasks.io.persist_df`, whose `geoparquet` branch
+# writes the *same* gdf to `<hash>.parquet` as WKB, and it's possible for a spec
+# to use both. The prefix explicitly flags a geoarrow-encoded file whose content
+# hash may be the same as that of a WKB-encoded file from the same workflow.
+GEOARROW_FILENAME_PREFIX = "geoarrow_"
+
+
 @register()
 def persist_geoarrow_for_pydeck(
     gdf: Annotated[AnyGeoDataFrame, Field(description="GeoDataframe to persist as GeoArrow-encoded parquet")],
@@ -306,11 +315,14 @@ def persist_geoarrow_for_pydeck(
 
     When the filename is generated from the gdf content hash, a target that
     already exists is returned as-is rather than re-encoded and rewritten.
+    Generated names carry a `geoarrow_` prefix, because the content hash alone
+    is not enough to tell the two encodings of a gdf apart — see
+    `GEOARROW_FILENAME_PREFIX`.
     """
 
     content_addressed = not filename
     if content_addressed:
-        filename = f"{_hash_df(gdf)}"  # type: ignore[arg-type] # mypy doesn't see that `AnyGeoDataFrame` is a subset of `AnyDataFrame`
+        filename = f"{GEOARROW_FILENAME_PREFIX}{_hash_df(gdf)}"  # type: ignore[arg-type] # mypy doesn't see that `AnyGeoDataFrame` is a subset of `AnyDataFrame`
     target = f"{filename}.parquet"
 
     if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:

--- a/ecoscope/platform/tasks/results/_map_utils.py
+++ b/ecoscope/platform/tasks/results/_map_utils.py
@@ -1,4 +1,3 @@
-import hashlib
 import io
 import json
 import re
@@ -13,7 +12,7 @@ from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
 
 from ecoscope.platform.annotations import AdvancedField, AnyGeoDataFrame
-from ecoscope.platform.serde import _persist_bytes
+from ecoscope.platform.serde import _persist_bytes, _read_path_if_file_exists
 
 OpacityAnnotation = Annotated[
     float,
@@ -303,14 +302,26 @@ def persist_geoarrow_for_pydeck(
     Intended for use with the maps created by this module, use
     `tasks.io.persist_df(filetype='geoparquet')` instead when writing for
     standard WKB-expecting consumers (e.g. QGIS, PostGIS)
+
+    When the filename is generated from the gdf content hash, a target that
+    already exists is returned as-is rather than re-encoded and rewritten.
     """
 
-    if not filename:
-        try:
-            hash_input = bytes(pd.util.hash_pandas_object(gdf).values)
-        except (TypeError, ValueError):
-            hash_input = f"{gdf.shape}{gdf.head(5).to_dict()}".encode()
-        filename = hashlib.sha256(hash_input).hexdigest()[:7]
+    content_addressed = not filename
+    if content_addressed:
+        # Local import: keeps `results` from pulling in `io/__init__` (and
+        # `_earthranger`) at import time, matching this module's lazy-import style.
+        from ecoscope.platform.tasks.io._persist import _hash_df
+
+        # `_geoarrow` qualifier: `persist_df(filetype="geoparquet")` derives its
+        # name from the same `_hash_df` but writes WKB, not geoarrow. Without the
+        # qualifier both target `<hash>.parquet` and the skip below would hand
+        # back one encoding in place of the other.
+        filename = f"{_hash_df(gdf)}_geoarrow"
+    target = f"{filename}.parquet"
+
+    if content_addressed and (existing := _read_path_if_file_exists(root_path, target)) is not None:
+        return existing
 
     gdf = gpd.GeoDataFrame(gdf).copy()
     _iso_format_timestamp_columns(gdf)
@@ -319,4 +330,4 @@ def persist_geoarrow_for_pydeck(
     _stringify_mixed_json(gdf)
     buffer = io.BytesIO()
     gdf.to_parquet(buffer, index=False, geometry_encoding="geoarrow")
-    return _persist_bytes(buffer.getvalue(), root_path, f"{filename}.parquet")
+    return _persist_bytes(buffer.getvalue(), root_path, target)

--- a/ecoscope/platform/tasks/transformation/_sql_query.py
+++ b/ecoscope/platform/tasks/transformation/_sql_query.py
@@ -189,8 +189,11 @@ def apply_sql_query(
             geom_name = df.geometry.name
             original_crs = df.crs  # type: ignore[assignment]
             attrs = sanitize_for_arrow(df.drop(columns=[geom_name]))
-            # Preserve the geometry column; the WKT round-trip below handles it.
-            df = gpd.GeoDataFrame(attrs.join(df[[geom_name]]), geometry=geom_name, crs=original_crs)
+            # Reattach geometry positionally rather than via `.join`.
+            # which aligns on the index, and creates duplication in
+            # cases where frames carry non-unique indexes
+            attrs[geom_name] = df[geom_name].to_numpy()
+            df = gpd.GeoDataFrame(attrs, geometry=geom_name, crs=original_crs)
         else:
             df = cast(AnyDataFrame, sanitize_for_arrow(df))
 

--- a/tests/platform/tasks/test_io_earthranger.py
+++ b/tests/platform/tasks/test_io_earthranger.py
@@ -1610,6 +1610,61 @@ class TestDownloadGroupedEventAttachments:
         assert attachment_path.exists()
         assert result == [f"custom/{expected_dirname}/attachment.jpg"]
 
+    def test_same_named_attachments_on_one_event_keep_the_first(self, output_dir, tmp_path):
+        # Each event has its own folder, so a clash means two attachments on this
+        # event share a filename. The first is kept and the second is not written:
+        # overwriting would fail anyway on gs://, where replacing an object needs
+        # a delete permission the workflow service account does not have.
+        class DuplicateNameClient(DummyEarthRangerClient):
+            def _get(self, url, return_response=False):
+                self.calls.append((url, return_response))
+                if url.endswith("/files"):
+                    return {
+                        "results": [
+                            {"id": "file-1", "filename": "image.jpg"},
+                            {"id": "file-2", "filename": "image.jpg"},
+                        ]
+                    }
+                if return_response:
+                    return DummyResponse(url.rsplit("/file/", 1)[1].split("/")[0].encode())
+                return {"results": []}
+
+        client = DuplicateNameClient()
+        event_id = "evt-dupe"
+        key = (("event_type", "=", "carcass"),)
+        expected_dirname = f"{_hash_grouper_key(key)}_{event_id}"
+
+        result = download_grouped_event_attachments(
+            client=client,
+            grouped_event_gdfs=[(key, self._make_df(event_id))],
+            output_dir=output_dir,
+        )
+
+        assert result == [f"attachments/{expected_dirname}/image.jpg"] * 2
+        assert (tmp_path / result[0]).read_bytes() == b"file-1", "the first attachment must survive"
+        fetched = [url for url, _ in client.calls if "/original/" in url]
+        assert len(fetched) == 1, "the colliding second attachment must not be downloaded"
+
+    def test_existing_attachment_is_neither_refetched_nor_rewritten(self, output_dir, tmp_path):
+        event_id = "evt-repeat"
+        key = (("event_type", "=", "carcass"),)
+        expected_dirname = f"{_hash_grouper_key(key)}_{event_id}"
+        args = dict(grouped_event_gdfs=[(key, self._make_df(event_id))], output_dir=output_dir)
+
+        first = download_grouped_event_attachments(client=DummyEarthRangerClient(), **args)
+        assert first == [f"attachments/{expected_dirname}/attachment.jpg"]
+
+        # Sentinel proves the second run leaves the existing file alone.
+        (tmp_path / first[0]).write_bytes(b"sentinel")
+
+        client2 = DummyEarthRangerClient()
+        second = download_grouped_event_attachments(client=client2, **args)
+
+        assert second == first
+        assert (tmp_path / first[0]).read_bytes() == b"sentinel"
+        refetches = [url for url, _ in client2.calls if "/original/" in url]
+        assert not refetches, "an attachment already on disk must not be refetched"
+
     def test_none_key_group_is_skipped(self, dummy_er_client, output_dir, tmp_path):
         key = (("event_type", "=", "carcass"),)
         result = download_grouped_event_attachments(

--- a/tests/platform/tasks/test_io_persist.py
+++ b/tests/platform/tasks/test_io_persist.py
@@ -116,6 +116,64 @@ def test_persist_json_accepts_basemodel(tmp_path):
     assert loaded["views"] == {"@@type": "MapView"}
 
 
+def test_persist_text_generated_filename_skips_rewrite(tmp_path):
+    root_path = str(tmp_path / "test")
+
+    dst = persist_text("<div>map</div>", root_path)
+    Path(dst).write_text("sentinel")
+
+    assert persist_text("<div>map</div>", root_path) == dst
+    assert Path(dst).read_text() == "sentinel", "existing target must not be rewritten"
+
+
+def test_persist_text_generated_filename_with_suffix_skips_rewrite(tmp_path):
+    """`content_addressed` is captured before `filename_suffix` mutates the name.
+
+    The suffix is a per-task constant, so hash + suffix is still fully determined
+    by the content.
+    """
+    root_path = str(tmp_path / "test")
+
+    dst = persist_text("<div>map</div>", root_path, filename_suffix="v2")
+    assert dst.endswith("_v2.html")
+    Path(dst).write_text("sentinel")
+
+    assert persist_text("<div>map</div>", root_path, filename_suffix="v2") == dst
+    assert Path(dst).read_text() == "sentinel"
+
+
+def test_persist_text_explicit_filename_overwrites(tmp_path):
+    root_path = str(tmp_path / "test")
+    persist_text("first", root_path, "map.html")
+    dst = persist_text("second", root_path, "map.html")
+
+    assert Path(dst).read_text() == "second"
+
+
+def test_persist_json_generated_filename_skips_rewrite(tmp_path):
+    root_path = str(tmp_path / "test")
+
+    dst = persist_json({"a": 1}, root_path)
+    Path(dst).write_text("sentinel")
+
+    assert persist_json({"a": 1}, root_path) == dst
+    assert Path(dst).read_text() == "sentinel"
+
+
+def test_persist_json_extensionless_explicit_filename_overwrites(tmp_path):
+    """The `elif not Path(filename).suffix` branch must not read as content-addressed.
+
+    It appends `.json` to a *caller-supplied* stem, so the resulting name still
+    says nothing about the content.
+    """
+    root_path = str(tmp_path / "test")
+    persist_json({"a": 1}, root_path, filename="map")
+    dst = persist_json({"a": 2}, root_path, filename="map")
+
+    assert dst.endswith("map.json")
+    assert json.loads(Path(dst).read_text()) == {"a": 2}
+
+
 class TestPersistDfForResultsDownload:
     """Tests for persist_grouped_dfs_for_results_download."""
 
@@ -198,67 +256,3 @@ class TestPersistDfForResultsDownload:
 
         assert persist_grouped_dfs_for_results_download(**args) == [dst]
         assert Path(dst).read_text() == "sentinel"
-
-
-# ---------------------------------------------------------------------------
-# Skip-if-exists for content-addressed filenames. See the module docstring of
-# the equivalent block in test_persist.py for the production failure these pin.
-# ---------------------------------------------------------------------------
-
-
-def test_persist_text_generated_filename_skips_rewrite(tmp_path):
-    root_path = str(tmp_path / "test")
-
-    dst = persist_text("<div>map</div>", root_path)
-    Path(dst).write_text("sentinel")
-
-    assert persist_text("<div>map</div>", root_path) == dst
-    assert Path(dst).read_text() == "sentinel", "existing target must not be rewritten"
-
-
-def test_persist_text_generated_filename_with_suffix_skips_rewrite(tmp_path):
-    """`content_addressed` is captured before `filename_suffix` mutates the name.
-
-    The suffix is a per-task constant, so hash + suffix is still fully determined
-    by the content.
-    """
-    root_path = str(tmp_path / "test")
-
-    dst = persist_text("<div>map</div>", root_path, filename_suffix="v2")
-    assert dst.endswith("_v2.html")
-    Path(dst).write_text("sentinel")
-
-    assert persist_text("<div>map</div>", root_path, filename_suffix="v2") == dst
-    assert Path(dst).read_text() == "sentinel"
-
-
-def test_persist_text_explicit_filename_overwrites(tmp_path):
-    root_path = str(tmp_path / "test")
-    persist_text("first", root_path, "map.html")
-    dst = persist_text("second", root_path, "map.html")
-
-    assert Path(dst).read_text() == "second"
-
-
-def test_persist_json_generated_filename_skips_rewrite(tmp_path):
-    root_path = str(tmp_path / "test")
-
-    dst = persist_json({"a": 1}, root_path)
-    Path(dst).write_text("sentinel")
-
-    assert persist_json({"a": 1}, root_path) == dst
-    assert Path(dst).read_text() == "sentinel"
-
-
-def test_persist_json_extensionless_explicit_filename_overwrites(tmp_path):
-    """The `elif not Path(filename).suffix` branch must not read as content-addressed.
-
-    It appends `.json` to a *caller-supplied* stem, so the resulting name still
-    says nothing about the content.
-    """
-    root_path = str(tmp_path / "test")
-    persist_json({"a": 1}, root_path, filename="map")
-    dst = persist_json({"a": 2}, root_path, filename="map")
-
-    assert dst.endswith("map.json")
-    assert json.loads(Path(dst).read_text()) == {"a": 2}

--- a/tests/platform/tasks/test_io_persist.py
+++ b/tests/platform/tasks/test_io_persist.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+from pathlib import Path
 
 import pandas as pd
 
@@ -185,3 +186,79 @@ class TestPersistDfForResultsDownload:
 
     def test_empty_iterable_returns_empty_list(self, tmp_path):
         assert persist_grouped_dfs_for_results_download(grouped_dfs=[], root_path=str(tmp_path)) == []
+
+    def test_rerun_skips_rewrite(self, tmp_path):
+        """Threaded through all three layers: grouped -> wrapper -> _persist_df."""
+        df = pd.DataFrame({"a": [1, 2]})
+        key = (("event_type", "=", "wildlife_sighting"),)
+        args = dict(grouped_dfs=[(key, df)], root_path=str(tmp_path), filetypes=["csv"])
+
+        (dst,) = persist_grouped_dfs_for_results_download(**args)
+        Path(dst).write_text("sentinel")
+
+        assert persist_grouped_dfs_for_results_download(**args) == [dst]
+        assert Path(dst).read_text() == "sentinel"
+
+
+# ---------------------------------------------------------------------------
+# Skip-if-exists for content-addressed filenames. See the module docstring of
+# the equivalent block in test_persist.py for the production failure these pin.
+# ---------------------------------------------------------------------------
+
+
+def test_persist_text_generated_filename_skips_rewrite(tmp_path):
+    root_path = str(tmp_path / "test")
+
+    dst = persist_text("<div>map</div>", root_path)
+    Path(dst).write_text("sentinel")
+
+    assert persist_text("<div>map</div>", root_path) == dst
+    assert Path(dst).read_text() == "sentinel", "existing target must not be rewritten"
+
+
+def test_persist_text_generated_filename_with_suffix_skips_rewrite(tmp_path):
+    """`content_addressed` is captured before `filename_suffix` mutates the name.
+
+    The suffix is a per-task constant, so hash + suffix is still fully determined
+    by the content.
+    """
+    root_path = str(tmp_path / "test")
+
+    dst = persist_text("<div>map</div>", root_path, filename_suffix="v2")
+    assert dst.endswith("_v2.html")
+    Path(dst).write_text("sentinel")
+
+    assert persist_text("<div>map</div>", root_path, filename_suffix="v2") == dst
+    assert Path(dst).read_text() == "sentinel"
+
+
+def test_persist_text_explicit_filename_overwrites(tmp_path):
+    root_path = str(tmp_path / "test")
+    persist_text("first", root_path, "map.html")
+    dst = persist_text("second", root_path, "map.html")
+
+    assert Path(dst).read_text() == "second"
+
+
+def test_persist_json_generated_filename_skips_rewrite(tmp_path):
+    root_path = str(tmp_path / "test")
+
+    dst = persist_json({"a": 1}, root_path)
+    Path(dst).write_text("sentinel")
+
+    assert persist_json({"a": 1}, root_path) == dst
+    assert Path(dst).read_text() == "sentinel"
+
+
+def test_persist_json_extensionless_explicit_filename_overwrites(tmp_path):
+    """The `elif not Path(filename).suffix` branch must not read as content-addressed.
+
+    It appends `.json` to a *caller-supplied* stem, so the resulting name still
+    says nothing about the content.
+    """
+    root_path = str(tmp_path / "test")
+    persist_json({"a": 1}, root_path, filename="map")
+    dst = persist_json({"a": 2}, root_path, filename="map")
+
+    assert dst.endswith("map.json")
+    assert json.loads(Path(dst).read_text()) == {"a": 2}

--- a/tests/platform/tasks/test_map_utils.py
+++ b/tests/platform/tasks/test_map_utils.py
@@ -243,17 +243,6 @@ def test_persist_geoarrow_for_pydeck_skips_non_color_object_columns(tmp_path) ->
     assert schema.field("ragged").type != pa.list_(pa.uint8(), 4)
 
 
-# ---------------------------------------------------------------------------
-# Skip-if-exists for content-addressed filenames.
-#
-# `persist_geoarrow_for_pydeck` is one of the two tasks observed failing in
-# production: several grouped views render the same small or empty layer, so
-# they derive the same content hash and the second write tries to overwrite the
-# first -- which fails on a gs:// root, where replacing an object needs a delete
-# permission the workflow service account does not have.
-# ---------------------------------------------------------------------------
-
-
 def _skip_test_gdf() -> gpd.GeoDataFrame:
     return gpd.GeoDataFrame(
         {"a": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]},

--- a/tests/platform/tasks/test_map_utils.py
+++ b/tests/platform/tasks/test_map_utils.py
@@ -287,23 +287,3 @@ def test_persist_geoarrow_explicit_filename_overwrites(tmp_path) -> None:
 
     assert persist_geoarrow_for_pydeck(gdf, root_path, filename="layer") == dst
     assert Path(dst).read_bytes() != b"sentinel"
-
-
-def test_persist_geoarrow_does_not_collide_with_geoparquet(tmp_path) -> None:
-    """Both tasks derive their name from the same `_hash_df` of the same frame.
-
-    They write different encodings, though -- geoarrow here, WKB in `persist_df`
-    -- so sharing `<hash>.parquet` would make the skip hand back one encoding in
-    place of the other. The generated stem is qualified to keep them apart.
-    """
-    gdf = _skip_test_gdf()
-    root_path = str(tmp_path / "out")
-
-    geoarrow = persist_geoarrow_for_pydeck(gdf, root_path)
-    wkb = persist_df(gdf, root_path, None, "geoparquet")
-
-    assert geoarrow != wkb
-    assert Path(geoarrow).exists() and Path(wkb).exists()
-    for path in (geoarrow, wkb):
-        assert len(gpd.read_parquet(path)) == 2
-    assert pq.read_schema(geoarrow) != pq.read_schema(wkb), "the two encodings really do differ"

--- a/tests/platform/tasks/test_map_utils.py
+++ b/tests/platform/tasks/test_map_utils.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from unittest import mock
+
 import geopandas as gpd  # type: ignore[import-untyped]
 import pandas as pd
 import pyarrow as pa
@@ -6,6 +9,8 @@ import pytest
 from pydantic import ValidationError
 from shapely.geometry import Point
 
+from ecoscope.platform.tasks.io import persist_df
+from ecoscope.platform.tasks.results import _map_utils
 from ecoscope.platform.tasks.results._map_utils import (
     DEFAULT_TILE_LAYER_PRESETS,
     TileLayer,
@@ -236,3 +241,80 @@ def test_persist_geoarrow_for_pydeck_skips_non_color_object_columns(tmp_path) ->
     # (list/struct/binary), but it must NOT be uint8 fixed-size-list.
     assert schema.field("ragged").type != pa.list_(pa.uint8(), 3)
     assert schema.field("ragged").type != pa.list_(pa.uint8(), 4)
+
+
+# ---------------------------------------------------------------------------
+# Skip-if-exists for content-addressed filenames.
+#
+# `persist_geoarrow_for_pydeck` is one of the two tasks observed failing in
+# production: several grouped views render the same small or empty layer, so
+# they derive the same content hash and the second write tries to overwrite the
+# first -- which fails on a gs:// root, where replacing an object needs a delete
+# permission the workflow service account does not have.
+# ---------------------------------------------------------------------------
+
+
+def _skip_test_gdf() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"a": [1, 2], "geometry": [Point(0, 0), Point(1, 1)]},
+        crs="EPSG:4326",
+    )
+
+
+def test_persist_geoarrow_generated_filename_skips_rewrite(tmp_path) -> None:
+    gdf = _skip_test_gdf()
+    root_path = str(tmp_path / "out")
+
+    dst = persist_geoarrow_for_pydeck(gdf, root_path)
+    Path(dst).write_bytes(b"sentinel")
+
+    assert persist_geoarrow_for_pydeck(gdf, root_path) == dst
+    assert Path(dst).read_bytes() == b"sentinel", "existing target must not be rewritten"
+
+
+def test_persist_geoarrow_identical_layers_share_one_file_without_rewriting(tmp_path) -> None:
+    """The grouped-views scenario that triggered the production failure.
+
+    Two views yielding byte-identical layers legitimately map to one
+    content-addressed file; the second call must return it rather than rewrite
+    it. Booby-trapping the write models the gs:// 403 directly -- on the real
+    bucket the second write is what fails, not the second hash.
+    """
+    root_path = str(tmp_path / "out")
+    view_a, view_b = _skip_test_gdf(), _skip_test_gdf()
+
+    first = persist_geoarrow_for_pydeck(view_a, root_path)
+
+    with mock.patch.object(_map_utils, "_persist_bytes", side_effect=AssertionError("must not attempt a second write")):
+        assert persist_geoarrow_for_pydeck(view_b, root_path) == first
+
+
+def test_persist_geoarrow_explicit_filename_overwrites(tmp_path) -> None:
+    root_path = str(tmp_path / "out")
+    gdf = _skip_test_gdf()
+
+    dst = persist_geoarrow_for_pydeck(gdf, root_path, filename="layer")
+    Path(dst).write_bytes(b"sentinel")
+
+    assert persist_geoarrow_for_pydeck(gdf, root_path, filename="layer") == dst
+    assert Path(dst).read_bytes() != b"sentinel"
+
+
+def test_persist_geoarrow_does_not_collide_with_geoparquet(tmp_path) -> None:
+    """Both tasks derive their name from the same `_hash_df` of the same frame.
+
+    They write different encodings, though -- geoarrow here, WKB in `persist_df`
+    -- so sharing `<hash>.parquet` would make the skip hand back one encoding in
+    place of the other. The generated stem is qualified to keep them apart.
+    """
+    gdf = _skip_test_gdf()
+    root_path = str(tmp_path / "out")
+
+    geoarrow = persist_geoarrow_for_pydeck(gdf, root_path)
+    wkb = persist_df(gdf, root_path, None, "geoparquet")
+
+    assert geoarrow != wkb
+    assert Path(geoarrow).exists() and Path(wkb).exists()
+    for path in (geoarrow, wkb):
+        assert len(gpd.read_parquet(path)) == 2
+    assert pq.read_schema(geoarrow) != pq.read_schema(wkb), "the two encodings really do differ"

--- a/tests/platform/tasks/test_map_utils.py
+++ b/tests/platform/tasks/test_map_utils.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest import mock
 
@@ -13,6 +14,7 @@ from ecoscope.platform.tasks.io import persist_df
 from ecoscope.platform.tasks.results import _map_utils
 from ecoscope.platform.tasks.results._map_utils import (
     DEFAULT_TILE_LAYER_PRESETS,
+    GEOARROW_FILENAME_PREFIX,
     TileLayer,
     custom_tile_layer_json_schema,
     make_preset_or_custom_json_schema_extra,
@@ -276,6 +278,37 @@ def test_persist_geoarrow_identical_layers_share_one_file_without_rewriting(tmp_
 
     with mock.patch.object(_map_utils, "_persist_bytes", side_effect=AssertionError("must not attempt a second write")):
         assert persist_geoarrow_for_pydeck(view_b, root_path) == first
+
+
+def _geometry_encoding(path: str) -> str:
+    """`"point"` for a geoarrow-encoded gdf, `"WKB"` for the standard encoding."""
+    return json.loads(pq.read_schema(path).metadata[b"geo"])["columns"]["geometry"]["encoding"]
+
+
+@pytest.mark.parametrize("geoarrow_first", [True, False])
+def test_persist_geoarrow_target_does_not_collide_with_geoparquet(tmp_path, geoarrow_first) -> None:
+    """Both tasks hash the same gdf with `_hash_df` and both write `.parquet`.
+
+    Without `GEOARROW_FILENAME_PREFIX` they share one target, so whichever ran
+    second skipped its write and returned the other's file: WKB handed to a
+    geoarrow layer, or geoarrow handed to QGIS, decided by task order. The
+    docstrings point specs at both tasks, so one `root_path` holding both is a
+    supported arrangement, not a misuse.
+    """
+    gdf = _points_gdf()
+    root_path = str(tmp_path / "out")
+
+    if geoarrow_first:
+        arrow_path = persist_geoarrow_for_pydeck(gdf, root_path)
+        wkb_path = persist_df(gdf, root_path, None, "geoparquet")
+    else:
+        wkb_path = persist_df(gdf, root_path, None, "geoparquet")
+        arrow_path = persist_geoarrow_for_pydeck(gdf, root_path)
+
+    assert arrow_path != wkb_path
+    assert Path(arrow_path).name.startswith(GEOARROW_FILENAME_PREFIX)
+    assert _geometry_encoding(arrow_path) == "point", "the pydeck consumer must get geoarrow"
+    assert _geometry_encoding(wkb_path) == "WKB", "the QGIS/PostGIS consumer must get WKB"
 
 
 def test_persist_geoarrow_explicit_filename_overwrites(tmp_path) -> None:

--- a/tests/platform/tasks/test_persist.py
+++ b/tests/platform/tasks/test_persist.py
@@ -283,3 +283,46 @@ def test_persist_df_wrapper_sanitize_changes_the_filename(tmp_path):
     sanitized = persist_df_wrapper(df=df, root_path=root_path, filetypes=["csv"], sanitize=True)
 
     assert plain != sanitized
+
+
+def test_persist_df_geoparquet_without_geometry_raises(tmp_path):
+    """geopandas does not raise here -- it writes `primary_column: null` metadata
+    that only a later `gpd.read_parquet` rejects. `_require_geometry` makes it loud.
+    """
+    with pytest.raises(ValueError, match="requires at least one geometry column"):
+        persist_df(pd.DataFrame({"A": [1]}), str(tmp_path / "test"), None, "geoparquet")
+
+
+@pytest.mark.parametrize("filetypes", [["parquet", "geoparquet"], ["geoparquet", "parquet"]])
+def test_persist_df_wrapper_geoparquet_without_geometry_raises_either_order(tmp_path, filetypes):
+    """`parquet` and `geoparquet` share `<hash>.parquet`.
+
+    Without the guard, list order decided the outcome: parquet-first wrote a clean
+    plain parquet and the geoparquet encode was skipped, geoparquet-first wrote the
+    unreadable one and the plain encode was skipped -- same returned path, different
+    content. The guard rejects the frame the same way whichever order it arrives in.
+    """
+    with pytest.raises(ValueError, match="requires at least one geometry column"):
+        persist_df_wrapper(df=pd.DataFrame({"A": [1]}), root_path=str(tmp_path / "test"), filetypes=filetypes)
+
+
+def test_persist_df_geoparquet_guard_runs_before_the_skip(tmp_path):
+    """The guard must precede the skip probe, or an existing `<hash>.parquet` left
+    by the `parquet` branch would let a geometry-less geoparquet call return it.
+    """
+    df = pd.DataFrame({"A": [1]})
+    root_path = str(tmp_path / "test")
+
+    plain = persist_df(df, root_path, None, "parquet")
+    assert Path(plain).exists(), "the shared target must already be on disk"
+
+    with pytest.raises(ValueError, match="requires at least one geometry column"):
+        persist_df(df, root_path, None, "geoparquet")
+
+
+def test_persist_df_geoparquet_with_geometry_still_writes(tmp_path):
+    gdf = gpd.GeoDataFrame({"A": [1], "geometry": [Point(0, 0)]})
+    dst = persist_df(gdf, str(tmp_path / "test"), None, "geoparquet")
+
+    assert dst.endswith(".parquet")
+    assert len(gpd.read_parquet(dst)) == 1

--- a/tests/platform/tasks/test_persist.py
+++ b/tests/platform/tasks/test_persist.py
@@ -239,6 +239,34 @@ def test_persist_df_hash_distinguishes_int_from_str_in_mixed_column(tmp_path):
     assert persist_df(a, root_path, None, "csv") != persist_df(b, root_path, None, "csv")
 
 
+def test_hash_df_raises_clearly_when_values_are_neither_hashable_nor_reprable():
+    """The fallback's own `repr` can fail; the error must name the column.
+
+    There is no honest name to write under in that case -- a type-derived
+    placeholder collides across distinct values and an `id`-derived one changes
+    per process, either of which would make skip-if-exists serve wrong bytes --
+    so `_hash_df` raises rather than inventing a hash. Object-dtype hashing is
+    forced to fail here so the test pins our wrapping, not pandas' internals.
+    """
+
+    class Unreprable:
+        def __repr__(self):
+            raise RuntimeError("boom")
+
+    df = pd.DataFrame({"bad": [Unreprable()]})
+    real = pd.util.hash_pandas_object
+
+    def failing_on_object_dtype(obj, **kwargs):
+        dtypes = obj.dtypes if isinstance(obj, pd.DataFrame) else [obj.dtype]
+        if any(dtype == object for dtype in dtypes):
+            raise TypeError("unhashable type")
+        return real(obj, **kwargs)
+
+    with mock.patch.object(pd.util, "hash_pandas_object", failing_on_object_dtype):
+        with pytest.raises(TypeError, match="cannot content-hash column 'bad'"):
+            _hash_df(df)
+
+
 def test_hash_df_hot_path_avoids_the_per_column_fallback(tmp_path):
     """Ordinary frames must take the single whole-frame hash.
 

--- a/tests/platform/tasks/test_persist.py
+++ b/tests/platform/tasks/test_persist.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+from unittest import mock
+
 import geopandas as gpd  # type: ignore[import-untyped]
 import pandas as pd
+import pytest
 from shapely.geometry import Point
 
-from ecoscope.platform.tasks.io import persist_df
+from ecoscope.platform.tasks.io import persist_df, persist_df_wrapper
+from ecoscope.platform.tasks.io._persist import _hash_df
 
 
 def test_persist_df_auto_filename_hashable(tmp_path):
@@ -121,3 +126,160 @@ def test_persist_df_geojson(tmp_path):
     assert dst.endswith(".geojson")
     gdf_read = gpd.read_file(dst)
     pd.testing.assert_frame_equal(gdf_read[["A", "geometry"]], gdf, check_dtype=False)
+
+
+# ---------------------------------------------------------------------------
+# Skip-if-exists for content-addressed filenames.
+#
+# The production failure these pin: within one workflow run two tasks produce
+# byte-identical output, so they derive the same content hash and the second
+# write overwrites the first. On a gs:// root that overwrite fails outright,
+# because replacing an object needs a delete permission the workflow service
+# account does not have.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("filetype", ["csv", "gpkg", "parquet", "geoparquet"])
+def test_persist_df_auto_filename_skips_rewrite(tmp_path, filetype):
+    gdf = gpd.GeoDataFrame(
+        {"A": [1, 2, 3], "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)]},
+    )
+    root_path = str(tmp_path / "test")
+
+    dst = persist_df(gdf, root_path, None, filetype)
+    Path(dst).write_bytes(b"sentinel")
+
+    assert persist_df(gdf, root_path, None, filetype) == dst
+    assert Path(dst).read_bytes() == b"sentinel", "existing target must not be rewritten"
+
+
+def test_persist_df_auto_filename_skips_serialization(tmp_path):
+    """Not just the write -- the encode is skipped too."""
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    root_path = str(tmp_path / "test")
+
+    dst = persist_df(df, root_path, None, "csv")
+
+    with mock.patch.object(pd.DataFrame, "to_csv", side_effect=AssertionError("should not serialize")):
+        assert persist_df(df, root_path, None, "csv") == dst
+
+
+def test_persist_df_explicit_filename_still_overwrites(tmp_path):
+    """A caller-supplied name does not determine its content, so it must not skip."""
+    root_path = str(tmp_path / "test")
+    persist_df(pd.DataFrame({"A": [1]}), root_path, "data", "csv")
+    dst = persist_df(pd.DataFrame({"A": [2]}), root_path, "data", "csv")
+
+    assert pd.read_csv(dst, index_col=0)["A"].tolist() == [2]
+
+
+@pytest.mark.parametrize(
+    ("filetype", "extension"),
+    [
+        ("csv", ".csv"),
+        ("gpkg", ".gpkg"),
+        ("geoparquet", ".parquet"),
+        ("parquet", ".parquet"),
+        ("geojson", ".geojson"),
+        ("json", ".json"),
+    ],
+)
+def test_persist_df_extension_per_filetype(tmp_path, filetype, extension):
+    gdf = gpd.GeoDataFrame({"A": [1], "geometry": [Point(0, 0)]})
+    dst = persist_df(gdf, str(tmp_path / "test"), "data", filetype)
+
+    assert dst.endswith(extension)
+
+
+def test_persist_df_unsupported_filetype_raises(tmp_path):
+    # Raised while resolving the extension, i.e. before any serialization.
+    with pytest.raises(NotImplementedError, match="Unsupported file type"):
+        persist_df(pd.DataFrame({"A": [1]}), str(tmp_path / "test"), "data", "xlsx")
+
+
+def test_persist_df_hash_covers_column_labels(tmp_path):
+    """Regression: `hash_pandas_object` hashes only values, never column labels.
+
+    With column-mapping tasks upstream of persist, a rename used to yield the
+    same filename for different content -- and under skip the second frame would
+    silently serve the first's file.
+    """
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    root_path = str(tmp_path / "test")
+
+    assert persist_df(df, root_path, None, "csv") != persist_df(df.rename(columns={"A": "Z"}), root_path, None, "csv")
+
+
+def test_persist_df_hash_covers_all_rows_for_unhashable_frames(tmp_path):
+    """Regression: the fallback used to hash only shape + `head(5)`.
+
+    Object columns holding lists/dicts (grouped event exports) take that path, so
+    two frames agreeing on shape and first rows collided.
+    """
+    root_path = str(tmp_path / "test")
+    rows = [{"k": i} for i in range(30)]
+    a = pd.DataFrame({"details": rows})
+    b = pd.DataFrame({"details": [*rows[:25], {"k": 999}, *rows[26:]]})
+
+    assert a.shape == b.shape
+    assert a.head(5).to_dict() == b.head(5).to_dict(), "must differ only past the old sample window"
+    assert persist_df(a, root_path, None, "csv") != persist_df(b, root_path, None, "csv")
+
+
+def test_persist_df_hash_distinguishes_int_from_str_in_mixed_column(tmp_path):
+    """The unhashable fallback coerces with `repr`, not `str`.
+
+    `str` would render 1 and "1" identically, collapsing two different frames
+    onto one filename.
+    """
+    root_path = str(tmp_path / "test")
+    a = pd.DataFrame({"x": [["l"], 1, "z"]})
+    b = pd.DataFrame({"x": [["l"], "1", "z"]})
+
+    assert persist_df(a, root_path, None, "csv") != persist_df(b, root_path, None, "csv")
+
+
+def test_hash_df_hot_path_avoids_the_per_column_fallback(tmp_path):
+    """Ordinary frames must take the single whole-frame hash.
+
+    The fallback feeds sha256 one array per column instead of one for the frame;
+    that is affordable only because ordinary frames never reach it.
+    """
+    df = pd.DataFrame({"s": ["a", "b"], "i": [1, 2], "f": [1.5, 2.5]})
+    real = pd.util.hash_pandas_object
+    calls = []
+
+    def counting(obj, **kwargs):
+        calls.append(obj)
+        return real(obj, **kwargs)
+
+    with mock.patch.object(pd.util, "hash_pandas_object", counting):
+        _hash_df(df)
+
+    assert len(calls) == 1
+
+
+def test_persist_df_wrapper_auto_filename_skips_rewrite(tmp_path):
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    root_path = str(tmp_path / "test")
+
+    (dst,) = persist_df_wrapper(df=df, root_path=root_path, filetypes=["csv"])
+    Path(dst).write_bytes(b"sentinel")
+
+    assert persist_df_wrapper(df=df, root_path=root_path, filetypes=["csv"]) == [dst]
+    assert Path(dst).read_bytes() == b"sentinel"
+
+
+def test_persist_df_wrapper_sanitize_changes_the_filename(tmp_path):
+    """Regression: the hash was taken of `df` while `df_new` was written.
+
+    `sanitize=True` and `sanitize=False` therefore shared a name for different
+    bytes, so under skip one would serve the other's file.
+    """
+    df = pd.DataFrame({"tags": [["a", "b"], ["c"]]})
+    root_path = str(tmp_path / "test")
+
+    plain = persist_df_wrapper(df=df, root_path=root_path, filetypes=["csv"], sanitize=False)
+    sanitized = persist_df_wrapper(df=df, root_path=root_path, filetypes=["csv"], sanitize=True)
+
+    assert plain != sanitized

--- a/tests/platform/tasks/test_persist.py
+++ b/tests/platform/tasks/test_persist.py
@@ -326,3 +326,52 @@ def test_persist_df_geoparquet_with_geometry_still_writes(tmp_path):
 
     assert dst.endswith(".parquet")
     assert len(gpd.read_parquet(dst)) == 1
+
+
+def test_persist_df_wrapper_sanitize_preserves_geodataframe(tmp_path):
+    """The sanitize branch splits geometry off, sanitizes the attributes and
+    reattaches -- the round trip must come back a GeoDataFrame with its CRS."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B"],
+            "tags": [["x", "y"], ["z"]],
+            "geometry": [Point(0, 0), Point(1, 1)],
+        },
+        crs="EPSG:4326",
+    )
+
+    dst = persist_df_wrapper(df=gdf, root_path=str(tmp_path / "test"), filetypes=["geoparquet"], sanitize=True)[0]
+
+    written = gpd.read_parquet(dst)
+    assert written.crs == gdf.crs
+    assert len(written) == 2
+    assert written["tags"].iloc[0] == '["x", "y"]'
+    assert written["geometry"].iloc[1].equals(Point(1, 1))
+
+
+def test_persist_df_wrapper_sanitize_geodataframe_with_repeat_index(tmp_path):
+    """Regression: geometry was reattached with `attrs.join(df[[geom_name]])`.
+
+    `.join` aligns on the index, so a frame carrying a non-unique index (as
+    grouped/exploded frames routinely do) got a cartesian expansion and we
+    persisted more rows than we were handed, with geometry paired to the
+    wrong attributes.
+    """
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "tags": [["x", "y"], ["z"], []],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        index=[0, 0, 1],
+        crs="EPSG:4326",
+    )
+
+    dst = persist_df_wrapper(df=gdf, root_path=str(tmp_path / "test"), filetypes=["geoparquet"], sanitize=True)[0]
+
+    written = gpd.read_parquet(dst)
+    assert written.crs == gdf.crs
+    assert len(written) == 3
+    assert list(written["name"]) == ["A", "B", "C"]
+    # Each row keeps the geometry it came in with
+    assert [g.equals(e) for g, e in zip(written["geometry"], gdf["geometry"])] == [True] * 3

--- a/tests/platform/tasks/test_sql_query.py
+++ b/tests/platform/tasks/test_sql_query.py
@@ -584,3 +584,77 @@ def test_sanitize_geodataframe_preserves_geometry_with_complex_columns():
     assert len(result) == 2
     assert result["geometry"].iloc[0].equals(Point(1, 1))
     assert result["tags"].iloc[0] == '["z"]'
+
+
+def test_sanitize_geodataframe_with_repeat_index_does_not_duplicate_rows():
+    """Regression: geometry was reattached with `attrs.join(df[[geom_name]])`.
+
+    `.join` aligns on the index, so a frame carrying a non-unique index (as
+    grouped/exploded frames routinely do) got a cartesian expansion -- three
+    rows in, five rows out, with geometry smeared across the wrong attributes.
+    Reattaching positionally keeps the frame the shape it arrived in.
+    """
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "tags": [["x", "y"], ["z"], []],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        index=[0, 0, 1],
+        crs="EPSG:4326",
+    )
+
+    result = apply_sql_query(gdf, "")
+
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result.crs == gdf.crs
+    assert len(result) == 3
+    assert list(result.index) == [0, 0, 1]
+    assert list(result["name"]) == ["A", "B", "C"]
+    # Each row keeps the geometry it came in with
+    assert [g.equals(e) for g, e in zip(result["geometry"], gdf["geometry"])] == [True] * 3
+    assert result["tags"].iloc[0] == '["x", "y"]'
+
+
+def test_sanitize_geodataframe_with_repeat_index_queries_the_original_rows():
+    """The row explosion happened before the query ran, so a filtering query on a
+    repeat-index frame matched rows that never existed in the input."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "value": [10, 20, 30],
+            "tags": [["x"], ["y"], ["z"]],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        index=[0, 0, 1],
+        crs="EPSG:4326",
+    )
+
+    result = apply_sql_query(gdf, "SELECT name, value, geometry FROM df WHERE value > 15")
+
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 2
+    assert list(result["name"]) == ["B", "C"]
+    assert result["geometry"].iloc[0].equals(Point(1, 1))
+    assert result["geometry"].iloc[1].equals(Point(2, 2))
+
+
+def test_sanitize_geodataframe_with_non_default_geometry_name():
+    """The reattach must use the frame's own geometry column name, not `geometry`."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "tags": [["x"], ["y"]],
+            "geom": [Point(0, 0), Point(1, 1)],
+        },
+        geometry="geom",
+        index=[7, 7],
+        crs="EPSG:4326",
+    )
+
+    result = apply_sql_query(gdf, "")
+
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result.geometry.name == "geom"
+    assert result.crs == gdf.crs
+    assert len(result) == 2
+    assert result["geom"].iloc[1].equals(Point(1, 1))

--- a/tests/platform/test_serde.py
+++ b/tests/platform/test_serde.py
@@ -2,12 +2,14 @@ import os
 
 import pytest
 
+from ecoscope.platform import serde
 from ecoscope.platform.serde import (
     _get_path,
     _gs_url_to_https_url,
     _my_content_type,
     _persist_bytes,
     _persist_text,
+    _read_path_if_file_exists,
 )
 
 
@@ -60,3 +62,85 @@ def test_persist_bytes_failure_when_target_is_dir(tmp_path) -> None:
 def test_get_path_unsupported_scheme_raises() -> None:
     with pytest.raises(ValueError, match="Unsupported scheme"):
         _get_path("s3://bucket/path", "x.txt")
+
+
+def test_read_path_if_file_exists_none_when_absent(tmp_path) -> None:
+    assert _read_path_if_file_exists(str(tmp_path / "root"), "nope.txt") is None
+
+
+def test_read_path_if_file_exists_matches_persist_text_return(tmp_path) -> None:
+    root_path = str(tmp_path / "root")
+    dst = _persist_text("hi", root_path, "name.txt")
+
+    assert _read_path_if_file_exists(root_path, "name.txt") == dst
+
+
+def test_read_path_if_file_exists_none_when_target_is_dir(tmp_path) -> None:
+    # Pins `is_file()` over `exists()`. Pairs with
+    # `test_persist_text_failure_when_target_is_dir`: a directory must not read as
+    # an existing file, so a content-addressed write still raises rather than
+    # silently skipping.
+    root_path = str(tmp_path / "root")
+    os.makedirs(os.path.join(root_path, "name.txt"))
+
+    assert _read_path_if_file_exists(root_path, "name.txt") is None
+
+
+def test_read_path_if_file_exists_none_for_zero_byte_file(tmp_path) -> None:
+    # A zero-length local file is the usual artifact of a crash mid-write, since
+    # local writes truncate before they write. Treat it as absent so the next run
+    # repairs it. GCS uploads are atomic, so the guard is local-only.
+    root_path = str(tmp_path / "root")
+    _persist_text("", root_path, "empty.txt")
+
+    assert _read_path_if_file_exists(root_path, "empty.txt") is None
+
+
+def test_read_path_if_file_exists_creates_missing_root_dir(tmp_path) -> None:
+    # Documents an inherited side effect of `_get_path`, not a desired one.
+    root_path = tmp_path / "created-by-probe"
+    assert _read_path_if_file_exists(str(root_path), "x.txt") is None
+    assert root_path.is_dir()
+
+
+def test_read_path_if_file_exists_unsupported_scheme_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported scheme"):
+        _read_path_if_file_exists("s3://bucket/path", "x.txt")
+
+
+def test_read_path_if_file_exists_is_scheme_agnostic(monkeypatch) -> None:
+    """Cover the non-local branch without needing GCS.
+
+    The repo has no GS mocking anywhere, so this pins our logic (probe the write
+    path, never stat a non-local one) rather than cloudpathlib's.
+    """
+
+    class FakeCloudPath:
+        def is_file(self):
+            return True
+
+    read_path = "https://storage.googleapis.com/bucket/dir/x.txt"
+    monkeypatch.setattr(serde, "_get_path", lambda root, name: (FakeCloudPath(), read_path))
+
+    # Not a local `Path`, so the zero-byte guard must not try to stat it.
+    assert _read_path_if_file_exists("gs://bucket/dir", "x.txt") == read_path
+
+
+def test_persist_text_always_overwrites(tmp_path) -> None:
+    # `_persist_*` must stay unconditional overwrites: skipping is a task-layer
+    # policy that only applies to content-addressed names.
+    root_path = str(tmp_path / "root")
+    _persist_text("first", root_path, "name.txt")
+    dst = _persist_text("second", root_path, "name.txt")
+
+    with open(dst) as f:
+        assert f.read() == "second"
+
+
+def test_persist_bytes_always_overwrites(tmp_path) -> None:
+    root_path = str(tmp_path / "root")
+    _persist_bytes(b"first", root_path, "name.bin")
+    dst = _persist_bytes(b"second", root_path, "name.bin")
+
+    with open(dst, "rb") as f:
+        assert f.read() == b"second"


### PR DESCRIPTION
## :earth_americas: Summary
Closes #826 

## :package: Proposed Changes
- Adds a check to the serde module to check if a file already exists or not
- Wires the above check into file persistence tasks where a content hash is used to generate the filename, if there's a collision we will no longer write anything
- Factoring changes to `_persist_df` for better readability
- Some improvements to`_hash_df` to coerce unhashable types

## 📋 Checklist
- [x] Corresponding ecoscope.platform tasks updated if necessary