### PR TITLE
Remove unsafe .join in `apply_sql_query` and `persist_df_wrapper`

### DIFF
--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -365,12 +365,9 @@ def persist_df_wrapper(
             geom_name = df.geometry.name
             attrs = df.drop(columns=[geom_name])
             attrs = cast(gpd.GeoDataFrame, sanitize_for_arrow(attrs))
-            # Reattach geometry positionally rather than via `.join`. `sanitize`
-            # preserves row order and count, so column-assignment aligns 1:1.
-            # A `.join` aligns on the index, and these frames routinely carry a
-            # non-unique index (e.g. per-observation `id` repeated across
-            # trajectory segments) which makes join do a many-to-many cartesian
-            # merge that explodes memory (1.6M rows -> tens of millions+).
+            # Reattach geometry positionally rather than via `.join`.
+            # which aligns on the index, and creates duplication in
+            # cases where frames carry non-unique indexes
             attrs[geom_name] = df[geom_name].to_numpy()
             df_new = cast(
                 AnyDataFrame,

--- a/ecoscope/platform/tasks/io/_persist.py
+++ b/ecoscope/platform/tasks/io/_persist.py
@@ -365,8 +365,17 @@ def persist_df_wrapper(
             geom_name = df.geometry.name
             attrs = df.drop(columns=[geom_name])
             attrs = cast(gpd.GeoDataFrame, sanitize_for_arrow(attrs))
-            # let geopandas handle geometry encoding
-            df_new = cast(AnyDataFrame, attrs.join(df[[geom_name]]))
+            # Reattach geometry positionally rather than via `.join`. `sanitize`
+            # preserves row order and count, so column-assignment aligns 1:1.
+            # A `.join` aligns on the index, and these frames routinely carry a
+            # non-unique index (e.g. per-observation `id` repeated across
+            # trajectory segments) which makes join do a many-to-many cartesian
+            # merge that explodes memory (1.6M rows -> tens of millions+).
+            attrs[geom_name] = df[geom_name].to_numpy()
+            df_new = cast(
+                AnyDataFrame,
+                gpd.GeoDataFrame(attrs, geometry=geom_name, crs=df.geometry.crs),
+            )
         else:
             df_new = cast(AnyDataFrame, sanitize_for_arrow(df))
     else:

--- a/ecoscope/platform/tasks/transformation/_sql_query.py
+++ b/ecoscope/platform/tasks/transformation/_sql_query.py
@@ -189,8 +189,14 @@ def apply_sql_query(
             geom_name = df.geometry.name
             original_crs = df.crs  # type: ignore[assignment]
             attrs = sanitize_for_arrow(df.drop(columns=[geom_name]))
-            # Preserve the geometry column; the WKT round-trip below handles it.
-            df = gpd.GeoDataFrame(attrs.join(df[[geom_name]]), geometry=geom_name, crs=original_crs)
+            # Reattach geometry positionally rather than via `.join`. `sanitize`
+            # preserves row order and count, so column-assignment aligns 1:1. A
+            # `.join` aligns on the index, and these frames routinely carry a
+            # non-unique index (e.g. per-observation `id` repeated across
+            # trajectory segments) which makes join do a many-to-many cartesian
+            # merge that explodes row count and memory.
+            attrs[geom_name] = df[geom_name].to_numpy()
+            df = gpd.GeoDataFrame(attrs, geometry=geom_name, crs=original_crs)
         else:
             df = cast(AnyDataFrame, sanitize_for_arrow(df))
 

--- a/ecoscope/platform/tasks/transformation/_sql_query.py
+++ b/ecoscope/platform/tasks/transformation/_sql_query.py
@@ -189,12 +189,9 @@ def apply_sql_query(
             geom_name = df.geometry.name
             original_crs = df.crs  # type: ignore[assignment]
             attrs = sanitize_for_arrow(df.drop(columns=[geom_name]))
-            # Reattach geometry positionally rather than via `.join`. `sanitize`
-            # preserves row order and count, so column-assignment aligns 1:1. A
-            # `.join` aligns on the index, and these frames routinely carry a
-            # non-unique index (e.g. per-observation `id` repeated across
-            # trajectory segments) which makes join do a many-to-many cartesian
-            # merge that explodes row count and memory.
+            # Reattach geometry positionally rather than via `.join`.
+            # which aligns on the index, and creates duplication in
+            # cases where frames carry non-unique indexes
             attrs[geom_name] = df[geom_name].to_numpy()
             df = gpd.GeoDataFrame(attrs, geometry=geom_name, crs=original_crs)
         else:

--- a/tests/platform/tasks/test_persist.py
+++ b/tests/platform/tasks/test_persist.py
@@ -326,3 +326,52 @@ def test_persist_df_geoparquet_with_geometry_still_writes(tmp_path):
 
     assert dst.endswith(".parquet")
     assert len(gpd.read_parquet(dst)) == 1
+
+
+def test_persist_df_wrapper_sanitize_preserves_geodataframe(tmp_path):
+    """The sanitize branch splits geometry off, sanitizes the attributes and
+    reattaches -- the round trip must come back a GeoDataFrame with its CRS."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B"],
+            "tags": [["x", "y"], ["z"]],
+            "geometry": [Point(0, 0), Point(1, 1)],
+        },
+        crs="EPSG:4326",
+    )
+
+    dst = persist_df_wrapper(df=gdf, root_path=str(tmp_path / "test"), filetypes=["geoparquet"], sanitize=True)[0]
+
+    written = gpd.read_parquet(dst)
+    assert written.crs == gdf.crs
+    assert len(written) == 2
+    assert written["tags"].iloc[0] == '["x", "y"]'
+    assert written["geometry"].iloc[1].equals(Point(1, 1))
+
+
+def test_persist_df_wrapper_sanitize_geodataframe_with_repeat_index(tmp_path):
+    """Regression: geometry was reattached with `attrs.join(df[[geom_name]])`.
+
+    `.join` aligns on the index, so a frame carrying a non-unique index (as
+    grouped/exploded frames routinely do) got a cartesian expansion and we
+    persisted more rows than we were handed, with geometry paired to the
+    wrong attributes.
+    """
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "tags": [["x", "y"], ["z"], []],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        index=[0, 0, 1],
+        crs="EPSG:4326",
+    )
+
+    dst = persist_df_wrapper(df=gdf, root_path=str(tmp_path / "test"), filetypes=["geoparquet"], sanitize=True)[0]
+
+    written = gpd.read_parquet(dst)
+    assert written.crs == gdf.crs
+    assert len(written) == 3
+    assert list(written["name"]) == ["A", "B", "C"]
+    # Each row keeps the geometry it came in with
+    assert [g.equals(e) for g, e in zip(written["geometry"], gdf["geometry"])] == [True] * 3

--- a/tests/platform/tasks/test_sql_query.py
+++ b/tests/platform/tasks/test_sql_query.py
@@ -584,3 +584,77 @@ def test_sanitize_geodataframe_preserves_geometry_with_complex_columns():
     assert len(result) == 2
     assert result["geometry"].iloc[0].equals(Point(1, 1))
     assert result["tags"].iloc[0] == '["z"]'
+
+
+def test_sanitize_geodataframe_with_repeat_index_does_not_duplicate_rows():
+    """Regression: geometry was reattached with `attrs.join(df[[geom_name]])`.
+
+    `.join` aligns on the index, so a frame carrying a non-unique index (as
+    grouped/exploded frames routinely do) got a cartesian expansion -- three
+    rows in, five rows out, with geometry smeared across the wrong attributes.
+    Reattaching positionally keeps the frame the shape it arrived in.
+    """
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "tags": [["x", "y"], ["z"], []],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        index=[0, 0, 1],
+        crs="EPSG:4326",
+    )
+
+    result = apply_sql_query(gdf, "")
+
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result.crs == gdf.crs
+    assert len(result) == 3
+    assert list(result.index) == [0, 0, 1]
+    assert list(result["name"]) == ["A", "B", "C"]
+    # Each row keeps the geometry it came in with
+    assert [g.equals(e) for g, e in zip(result["geometry"], gdf["geometry"])] == [True] * 3
+    assert result["tags"].iloc[0] == '["x", "y"]'
+
+
+def test_sanitize_geodataframe_with_repeat_index_queries_the_original_rows():
+    """The row explosion happened before the query ran, so a filtering query on a
+    repeat-index frame matched rows that never existed in the input."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["A", "B", "C"],
+            "value": [10, 20, 30],
+            "tags": [["x"], ["y"], ["z"]],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        index=[0, 0, 1],
+        crs="EPSG:4326",
+    )
+
+    result = apply_sql_query(gdf, "SELECT name, value, geometry FROM df WHERE value > 15")
+
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert len(result) == 2
+    assert list(result["name"]) == ["B", "C"]
+    assert result["geometry"].iloc[0].equals(Point(1, 1))
+    assert result["geometry"].iloc[1].equals(Point(2, 2))
+
+
+def test_sanitize_geodataframe_with_non_default_geometry_name():
+    """The reattach must use the frame's own geometry column name, not `geometry`."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "tags": [["x"], ["y"]],
+            "geom": [Point(0, 0), Point(1, 1)],
+        },
+        geometry="geom",
+        index=[7, 7],
+        crs="EPSG:4326",
+    )
+
+    result = apply_sql_query(gdf, "")
+
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result.geometry.name == "geom"
+    assert result.crs == gdf.crs
+    assert len(result) == 2
+    assert result["geom"].iloc[1].equals(Point(1, 1))


### PR DESCRIPTION
## :earth_americas: Summary
Closes #827 

## :package: Proposed Changes
- Updates `persist_df_wrapper` and `apply_sql_query` to reattach geometry positionally instead of via `.join`, in the case of duplicate indexes `.join` duplicates data in the frame

## 📋 Checklist
- [x] Corresponding ecoscope.platform tasks updated if necessary