### PR TITLE
Switch to trusted publishing for prefix releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,6 +141,8 @@ jobs:
     - build-for-prefix
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - name: Download built conda artifacts
@@ -157,8 +159,6 @@ jobs:
           for file in /tmp/ecoscope/release/artifacts/**/*.conda; do
             rattler-build upload prefix -c ecoscope-workflows "$file"
           done
-        env:
-          PREFIX_API_KEY: ${{ secrets.PREFIX_API_KEY }}
 
   publish-to-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## :earth_americas: Summary
Towards https://github.com/wildlife-dynamics/compose/issues/2740

## :package: Proposed Changes
Removes PREFIX_API_KEY, and sets `id-token: write` perms
Trusted publishing config on the prefix repo has been configured

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary