### PR TITLE
Respect active patrol types in `get_patrols`

### DIFF
--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -919,6 +919,7 @@ class EarthRangerIO(ERClient):
             A patrol type UUID or a list of UUIDs
         patrol_type_value:
             A patrol type value or a list of patrol type values
+            An empty list is treated as all active patrol types, None applies no patrol type filter
         status
             'scheduled'/'active'/'overdue'/'done'/'cancelled'
             Accept a status string or a list of statuses
@@ -951,12 +952,15 @@ class EarthRangerIO(ERClient):
             filter["patrol_type"] = params["patrol_type"]
         if patrol_type_value_list is not None:
             patrol_types = self.get_patrol_types()
-            matching_rows = patrol_types[patrol_types["value"].isin(patrol_type_value_list)]
-            missing_values = set(patrol_type_value_list) - set(matching_rows["value"])
-            if missing_values:
-                raise ValueError(f"Failed to find IDs for values: {missing_values}")
+            if patrol_type_value_list:
+                matching_rows = patrol_types[patrol_types["value"].isin(patrol_type_value_list)]
+                missing_values = set(patrol_type_value_list) - set(matching_rows["value"])
+                if missing_values:
+                    raise ValueError(f"Failed to find IDs for values: {missing_values}")
 
-            filter["patrol_type"] = matching_rows.index.tolist()
+                filter["patrol_type"] = matching_rows.index.tolist()
+            else:
+                filter["patrol_type"] = patrol_types.index.tolist()
         if filter.get("date_range", False):
             filter["patrols_overlap_daterange"] = patrols_overlap_daterange
 
@@ -1000,6 +1004,7 @@ class EarthRangerIO(ERClient):
             A patrol type UUID or a list of UUIDs
         patrol_type_value:
             A patrol type value or a list of patrol type values
+            An empty list is treated as all active patrol types, None applies no patrol type filter
         status
             'scheduled'/'active'/'overdue'/'done'/'cancelled'
             Accept a status string or a list of statuses
@@ -1086,6 +1091,7 @@ class EarthRangerIO(ERClient):
             A patrol type UUID or a list of UUIDs
         patrol_type_value:
             A patrol type value or a list of patrol type values
+            An empty list is treated as all active patrol types, None applies no patrol type filter
         status
             'scheduled'/'active'/'overdue'/'done'/'cancelled'
             Accept a status string or a list of statuses

--- a/ecoscope/io/earthranger.py
+++ b/ecoscope/io/earthranger.py
@@ -891,8 +891,22 @@ class EarthRangerIO(ERClient):
 
         return events_gdf
 
-    def get_patrol_types(self) -> pd.DataFrame:
-        df = pd.DataFrame(self._get("activity/patrols/types"))
+    def get_patrol_types(self, include_inactive: bool = False, **addl_kwargs) -> pd.DataFrame:
+        """
+        Return dataframe of ER patrol types, indexed by UUID.
+
+        Parameters
+        ----------
+        include_inactive: bool, default False
+            Whether to include inactive patrol types
+
+        Returns
+        -------
+        patrol_types : pd.DataFrame
+            DataFrame of patrol types, empty if the site has none
+        """
+        params = clean_kwargs(addl_kwargs, include_inactive=include_inactive)
+        df = pd.DataFrame(self._get("activity/patrols/types", params=params))
         if not df.empty:
             df = df.set_index("id")
         return df
@@ -917,9 +931,13 @@ class EarthRangerIO(ERClient):
             Upper time range
         patrol_type:
             A patrol type UUID or a list of UUIDs
+            Mutually exclusive with patrol_type_value
         patrol_type_value:
             A patrol type value or a list of patrol type values
-            An empty list is treated as all active patrol types, None applies no patrol type filter
+            An empty list is treated as all active patrol types, enumerated from `get_patrol_types`;
+            a ValueError is raised if the site has no active patrol types
+            None applies no patrol type filter
+            Mutually exclusive with patrol_type
         status
             'scheduled'/'active'/'overdue'/'done'/'cancelled'
             Accept a status string or a list of statuses
@@ -934,6 +952,8 @@ class EarthRangerIO(ERClient):
         """
 
         patrol_type_value_list = [patrol_type_value] if isinstance(patrol_type_value, str) else patrol_type_value
+        if patrol_type is not None and patrol_type_value_list is not None:
+            raise ValueError("patrol_type and patrol_type_value are mutually exclusive, provide only one")
         params = clean_kwargs(
             addl_kwargs,
             status=status,
@@ -951,7 +971,9 @@ class EarthRangerIO(ERClient):
         if patrol_type is not None:
             filter["patrol_type"] = params["patrol_type"]
         if patrol_type_value_list is not None:
-            patrol_types = self.get_patrol_types()
+            patrol_types = self.get_patrol_types(include_inactive=False)
+            if patrol_types.empty:
+                raise ValueError("EarthRanger returned no active patrol types to filter on")
             if patrol_type_value_list:
                 matching_rows = patrol_types[patrol_types["value"].isin(patrol_type_value_list)]
                 missing_values = set(patrol_type_value_list) - set(matching_rows["value"])
@@ -1002,9 +1024,13 @@ class EarthRangerIO(ERClient):
             Upper time range
         patrol_type:
             A patrol type UUID or a list of UUIDs
+            Mutually exclusive with patrol_type_value
         patrol_type_value:
             A patrol type value or a list of patrol type values
-            An empty list is treated as all active patrol types, None applies no patrol type filter
+            An empty list is treated as all active patrol types, enumerated from `get_patrol_types`;
+            a ValueError is raised if the site has no active patrol types
+            None applies no patrol type filter
+            Mutually exclusive with patrol_type
         status
             'scheduled'/'active'/'overdue'/'done'/'cancelled'
             Accept a status string or a list of statuses
@@ -1089,9 +1115,13 @@ class EarthRangerIO(ERClient):
             Upper time range
         patrol_type:
             A patrol type UUID or a list of UUIDs
+            Mutually exclusive with patrol_type_value
         patrol_type_value:
             A patrol type value or a list of patrol type values
-            An empty list is treated as all active patrol types, None applies no patrol type filter
+            An empty list is treated as all active patrol types, enumerated from `get_patrol_types`;
+            a ValueError is raised if the site has no active patrol types
+            None applies no patrol type filter
+            Mutually exclusive with patrol_type
         status
             'scheduled'/'active'/'overdue'/'done'/'cancelled'
             Accept a status string or a list of statuses

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -220,6 +220,67 @@ def test_get_patrols_patrol_type_value_filter(
     sent_filter = json.loads(get_objects_mock.mock_calls[0].kwargs["filter"])
     assert sent_filter["patrol_type"] == expected_patrol_type_filter
     assert patrol_types_mock.called == expect_lookup
+    if expect_lookup:
+        assert patrol_types_mock.mock_calls[0].kwargs == {"include_inactive": False}
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_include_inactive",
+    [
+        ({}, False),
+        ({"include_inactive": False}, False),
+        ({"include_inactive": True}, True),
+    ],
+)
+@patch("ecoscope.io.earthranger.EarthRangerIO._get")
+def test_get_patrol_types_include_inactive(get_mock, kwargs, expected_include_inactive, er_io):
+    get_mock.return_value = [
+        {"id": "id-a", "value": "a", "is_active": True},
+        {"id": "id-b", "value": "b", "is_active": False},
+    ]
+
+    patrol_types = er_io.get_patrol_types(**kwargs)
+
+    assert get_mock.mock_calls[0].kwargs["params"]["include_inactive"] is expected_include_inactive
+    assert patrol_types.index.tolist() == ["id-a", "id-b"]
+
+
+@patch("ecoscope.io.earthranger.EarthRangerIO._get")
+def test_get_patrol_types_empty(get_mock, er_io):
+    get_mock.return_value = []
+
+    assert er_io.get_patrol_types().empty
+
+
+@pytest.mark.parametrize("patrol_type_value", [[], ["a"]])
+@patch("ecoscope.io.earthranger.EarthRangerIO.get_objects_multithreaded")
+@patch("ecoscope.io.earthranger.EarthRangerIO.get_patrol_types")
+def test_get_patrols_raises_when_no_active_patrol_types(patrol_types_mock, get_objects_mock, patrol_type_value, er_io):
+    """
+    Without any active patrol types there is nothing to enumerate, and an empty patrol_type
+    filter would mean "every patrol type" rather than "none of them".
+    """
+    patrol_types_mock.return_value = pd.DataFrame()
+
+    with pytest.raises(ValueError, match="no active patrol types"):
+        er_io.get_patrols(since="2017-01-01", until="2017-04-01", patrol_type_value=patrol_type_value)
+
+    assert not get_objects_mock.called
+
+
+@patch("ecoscope.io.earthranger.EarthRangerIO.get_objects_multithreaded")
+@patch("ecoscope.io.earthranger.EarthRangerIO.get_patrol_types")
+def test_get_patrols_with_both_patrol_type_and_value_raises(patrol_types_mock, get_objects_mock, er_io):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        er_io.get_patrols(
+            since="2017-01-01",
+            until="2017-04-01",
+            patrol_type="1e2ec4dc-9c65-4b1f-8a1e-1b3a5b4c7d9e",
+            patrol_type_value="a",
+        )
+
+    assert not patrol_types_mock.called
+    assert not get_objects_mock.called
 
 
 def test_get_patrols_overlap_daterange_filters(er_io):

--- a/tests/test_earthranger_io.py
+++ b/tests/test_earthranger_io.py
@@ -187,6 +187,41 @@ def test_get_patrols_with_invalid_type_value(er_io):
         er_io.get_patrols(since="2017-01-01", until="2017-04-01", patrol_type_value="invalid")
 
 
+@pytest.mark.parametrize(
+    "patrol_type_value, expected_patrol_type_filter, expect_lookup",
+    [
+        (None, [], False),
+        ([], ["id-a", "id-b"], True),
+        (["a"], ["id-a"], True),
+        ("a", ["id-a"], True),
+    ],
+)
+@patch("ecoscope.io.earthranger.EarthRangerIO.get_objects_multithreaded")
+@patch("ecoscope.io.earthranger.EarthRangerIO.get_patrol_types")
+def test_get_patrols_patrol_type_value_filter(
+    patrol_types_mock,
+    get_objects_mock,
+    patrol_type_value,
+    expected_patrol_type_filter,
+    expect_lookup,
+    er_io,
+):
+    """
+    An empty patrol_type_value list means "all patrol types", enumerated from the
+    patrol types lookup, while None applies no patrol type filter at all.
+    """
+    patrol_types_mock.return_value = pd.DataFrame(
+        [{"id": "id-a", "value": "a"}, {"id": "id-b", "value": "b"}]
+    ).set_index("id")
+    get_objects_mock.return_value = {}
+
+    er_io.get_patrols(since="2017-01-01", until="2017-04-01", patrol_type_value=patrol_type_value)
+
+    sent_filter = json.loads(get_objects_mock.mock_calls[0].kwargs["filter"])
+    assert sent_filter["patrol_type"] == expected_patrol_type_filter
+    assert patrol_types_mock.called == expect_lookup
+
+
 def test_get_patrols_overlap_daterange_filters(er_io):
     since_str = "2017-02-05"
     until_str = "2017-03-01"


### PR DESCRIPTION
## :earth_americas: Summary
Closes #832

## :package: Proposed Changes
- Updates `get_patrols` to respect active patrol types if _any_ patrol type filter (even an empty one) is given.
  - We're explicitly distinguishing `None` (no filter) from `[]` (a proxy for "all active types")
- Updates `get_patrol_types` to add the `include_inactive` flag for completeness and to make the behaviour explicit

## 📋 Checklist
- [ ] Corresponding ecoscope.platform tasks updated if necessary