### PR TITLE
Allow users to define how `map_columns` handles duplicates

### DIFF
--- a/ecoscope/platform/tasks/transformation/_mapping.py
+++ b/ecoscope/platform/tasks/transformation/_mapping.py
@@ -1,6 +1,8 @@
 import logging
-from typing import Annotated, Literal, cast
+from collections.abc import Collection
+from typing import Annotated, Literal, cast, get_args
 
+import pandas as pd
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
@@ -104,6 +106,114 @@ def map_values_with_unit(
     return df
 
 
+RenameCollisionStrategy = Literal["overwrite", "skip", "error"]
+
+
+def _find_rename_collisions(columns: Collection[str], mapping: dict[str, str]) -> dict[str, str]:
+    """
+    Find the renames in `mapping` whose new name is already taken, either by a column that
+    isn't being renamed or by an earlier rename in `mapping`.
+
+    Args:
+        columns (Collection[str]): The current column names.
+        mapping (dict[str, str]): Mapping of existing column name to new column name.
+
+    Returns:
+        dict[str, str]: The colliding subset of `mapping`.
+    """
+    # The names that will still be occupied once the renames are applied, so that a swap
+    # (eg. {"A": "B", "B": "A"}) is not a collision.
+    taken = {col for col in columns if col not in mapping}
+
+    collisions: dict[str, str] = {}
+    for old, new in mapping.items():
+        if new in taken:
+            collisions[old] = new
+        else:
+            taken.add(new)
+
+    return collisions
+
+
+def _safe_rename_columns(
+    df: pd.DataFrame,
+    rename_columns: dict[str, str],
+    collision_strategy: RenameCollisionStrategy = "overwrite",
+) -> pd.DataFrame:
+    """
+    Rename columns, resolving new names that are already taken so that the result never contains
+    duplicate column labels.
+
+    `DataFrame.rename` will happily rename a column to a name that already exists, leaving the
+    frame with duplicate labels. `df[name]` then returns a DataFrame rather than a Series, which
+    tends to fail confusingly, far from the rename that caused it.
+
+    Args:
+        df (pd.DataFrame): The DataFrame to rename columns on.
+        rename_columns (dict[str, str]): Mapping of existing column name to new column name.
+        collision_strategy (RenameCollisionStrategy): How to resolve a new name that is already
+            taken, either by a column that isn't being renamed or by an earlier entry in
+            `rename_columns`:
+            - "overwrite": drop the column holding the name so the renamed one takes it
+            - "skip": skip the rename, leaving the column under its original name
+            - "error": raise ValueError
+
+    Returns:
+        pd.DataFrame: The DataFrame with columns renamed.
+
+    Raises:
+        ValueError: If `collision_strategy` is "error" and a new name is already taken.
+    """
+    if collision_strategy not in get_args(RenameCollisionStrategy):
+        raise ValueError(f"Invalid selection for collision_strategy: {collision_strategy}")
+
+    # Renames of absent columns are no-ops for pandas, so they can't collide, and identity
+    # renames leave the column exactly where it is.
+    mapping = {old: new for old, new in rename_columns.items() if old != new and old in df.columns}
+    if not mapping:
+        return df
+
+    if collision_strategy == "error":
+        if collisions := _find_rename_collisions(df.columns, mapping):
+            raise ValueError(
+                f"Renaming columns {mapping} would create duplicate columns: "
+                f"{sorted(set(collisions.values()))}. Existing columns: {list(df.columns)}"
+            )
+        return df.rename(columns=mapping)
+
+    if collision_strategy == "skip":
+        # Skipping a rename leaves its original name occupied, which can collide with a rename
+        # we had already accepted, so keep resolving until nothing collides.
+        skipped: dict[str, str] = {}
+        while collisions := _find_rename_collisions(df.columns, mapping):
+            skipped |= collisions
+            mapping = {old: new for old, new in mapping.items() if old not in collisions}
+        if skipped:
+            logger.warning(f"Not renaming columns whose new name is already taken: {skipped}")
+        return df.rename(columns=mapping)
+
+    # "overwrite": track which column will hold each name, so that the last rename to a given
+    # name wins and whatever held it - an untouched column, or a column renamed earlier - goes.
+    owner: dict[str, str] = {col: col for col in df.columns if col not in mapping}
+    resolved: dict[str, str] = {}
+    to_drop: list[str] = []
+    for old, new in mapping.items():
+        if new in owner:
+            displaced = owner.pop(new)
+            to_drop.append(displaced)
+            resolved.pop(displaced, None)
+        resolved[old] = new
+        owner[new] = old
+
+    if to_drop:
+        if "geometry" in to_drop:
+            logger.warning("'geometry' is being overwritten by a rename, which may affect spatial operations.")
+        logger.warning(f"Overwriting existing columns: {to_drop}")
+        df = df.drop(columns=to_drop)
+
+    return df.rename(columns=resolved)
+
+
 class RenameColumn(BaseModel):
     original_name: str
     new_name: str
@@ -131,6 +241,18 @@ def map_columns(
     raise_if_not_found: Annotated[
         bool, Field(description="Whether or not to raise if var is not in value_map.")
     ] = True,
+    collision_strategy: Annotated[
+        RenameCollisionStrategy,
+        AdvancedField(
+            default="overwrite",
+            description=(
+                "How to handle a rename whose new name is already taken. "
+                "'overwrite': replace the existing column; "
+                "'skip': skip the rename, leaving the column under its original name; "
+                "'error': raise ValueError."
+            ),
+        ),
+    ] = "overwrite",
 ) -> AnyDataFrame:
     """
     Maps and transforms the columns of a DataFrame based on the provided parameters. The order of the operations is as
@@ -142,12 +264,15 @@ def map_columns(
         retain_columns (list[str]): List of columns to retain. The order of columns will be preserved.
         rename_columns (dict[str, str]): Dictionary of columns to rename.
         raise_if_not_found (bool): Whether or not to raise in the event a column is not found.
+        collision_strategy (RenameCollisionStrategy): How to handle renaming a column to a name that is
+            already taken; see `_safe_rename_columns`.
 
     Returns:
         AnyDataFrame: The transformed DataFrame.
 
     Raises:
         KeyError: If any of the columns specified are not found in the DataFrame.
+        ValueError: If `collision_strategy` is "error" and a new column name is already taken.
     """
 
     if drop_columns:
@@ -173,7 +298,7 @@ def map_columns(
             raise KeyError(
                 f"Columns {list(rename_columns.keys())} not all found in DataFrame. Existing columns: {df.columns}"
             )
-        df = df.rename(columns=rename_columns)  # type: ignore[assignment]
+        df = _safe_rename_columns(df, rename_columns, collision_strategy)  # type: ignore[assignment]
 
     return cast(AnyDataFrame, df)
 
@@ -188,6 +313,7 @@ def title_case_columns_by_prefix(
 ) -> AnyDataFrame:
     """
     Convert the column names beginning with the provided prefix to title case.
+    A title cased name that is already taken overwrites the column holding it.
 
     Args:
         df (AnyDataFrame): The input DataFrame.
@@ -198,7 +324,7 @@ def title_case_columns_by_prefix(
     """
 
     mapping = {col: col.removeprefix(prefix).replace("_", " ").title() for col in df.columns if col.startswith(prefix)}
-    df = df.rename(columns=mapping)  # type: ignore[assignment]
+    df = _safe_rename_columns(df, mapping, "overwrite")  # type: ignore[assignment]
 
     return cast(AnyDataFrame, df)
 
@@ -267,6 +393,7 @@ def strip_prefix_from_column_names(
 ) -> AnyDataFrame:
     """
     Strip the provided prefix from column names that have it.
+    A stripped name that is already taken overwrites the column holding it.
 
     Args:
         df (AnyDataFrame): The input DataFrame.
@@ -275,7 +402,8 @@ def strip_prefix_from_column_names(
     Returns:
         AnyDataFrame: The updated DataFrame.
     """
-    df = df.rename(columns={col: col.removeprefix(prefix) for col in df.columns})  # type: ignore[assignment]
+    mapping = {col: col.removeprefix(prefix) for col in df.columns}
+    df = _safe_rename_columns(df, mapping, "overwrite")  # type: ignore[assignment]
     return cast(AnyDataFrame, df)
 
 

--- a/ecoscope/platform/tasks/transformation/_mapping.py
+++ b/ecoscope/platform/tasks/transformation/_mapping.py
@@ -31,7 +31,7 @@ def map_values(
 ) -> AnyDataFrame:
     match missing_values:
         case "preserve":
-            df[column_name] = df[column_name].map(value_map).fillna(df7[column_name])
+            df[column_name] = df[column_name].map(value_map).fillna(df[column_name])
         case "remove":
             df[column_name] = df[column_name].map(value_map)
         case "replace":

--- a/ecoscope/platform/tasks/transformation/_mapping.py
+++ b/ecoscope/platform/tasks/transformation/_mapping.py
@@ -105,7 +105,7 @@ def map_values_with_unit(
     return df
 
 
-RenameDuplicateStrategy = Literal["overwrite", "skip", "error"]
+RenameDuplicateStrategy = Literal["suffix", "skip", "overwrite", "error"]
 
 
 def _active_geometry_name(df: AnyDataFrame) -> str | None:
@@ -152,7 +152,7 @@ def _find_rename_collisions(columns: Collection[str], mapping: dict[str, str]) -
 def _safe_rename_columns(
     df: AnyDataFrame,
     rename_columns: dict[str, str],
-    duplicate_strategy: RenameDuplicateStrategy = "skip",
+    duplicate_strategy: RenameDuplicateStrategy,
 ) -> AnyDataFrame:
     """
     Rename columns, resolving new names that are already taken so that the renames never introduce
@@ -172,6 +172,7 @@ def _safe_rename_columns(
         duplicate_strategy (RenameDuplicateStrategy): How to resolve a new name that is already
             taken, either by a column that isn't being renamed or by an earlier entry in
             `rename_columns`:
+            - "suffix": append _1, _2, ... to the new name so both columns survive
             - "skip": skip the rename, leaving the column under its original name
             - "overwrite": drop the column holding the name so the renamed one takes it
             - "error": raise ValueError
@@ -219,6 +220,22 @@ def _safe_rename_columns(
             logger.warning(f"Not renaming columns whose new name is already taken: {skipped}")
         return cast(AnyDataFrame, df.rename(columns=mapping))
 
+    if duplicate_strategy == "suffix":
+        # Append _1, _2, ... so both columns survive, incrementing until the suffixed name is
+        # free too, since the plain _1 may itself already be taken.
+        taken = {col for col in df.columns if col not in mapping}
+        suffixed: dict[str, str] = {}
+        for old, new in mapping.items():
+            candidate, attempt = new, 0
+            while candidate in taken:
+                attempt += 1
+                candidate = f"{new}_{attempt}"
+            suffixed[old] = candidate
+            taken.add(candidate)
+        if renamed := {old: new for old, new in suffixed.items() if new != mapping[old]}:
+            logger.warning(f"Suffixing columns whose new name is already taken: {renamed}")
+        return cast(AnyDataFrame, df.rename(columns=suffixed))
+
     # "overwrite": track which column will hold each name, so that the last rename to a given
     # name wins and whatever held it - an untouched column, or a column renamed earlier - goes.
     owner: dict[str, str] = {col: col for col in df.columns if col not in mapping}
@@ -239,7 +256,7 @@ def _safe_rename_columns(
             raise ValueError(
                 f"Renaming columns {mapping} would overwrite the active geometry column "
                 f"'{active_geometry}'. Drop or rename it explicitly first, or use a "
-                "duplicate_strategy of 'skip' or 'error'."
+                "duplicate_strategy of 'skip', 'suffix' or 'error'."
             )
         if "geometry" in to_drop:
             logger.warning("'geometry' is being overwritten by a rename, which may affect spatial operations.")
@@ -279,15 +296,16 @@ def map_columns(
     duplicate_strategy: Annotated[
         RenameDuplicateStrategy,
         AdvancedField(
-            default="skip",
             description=(
                 "Strategy for handling a rename whose new name is already taken. "
+                "'suffix': append _1, _2, etc. to the new name; "
                 "'skip': skip the rename, leaving the column under its original name; "
                 "'overwrite': replace the existing column; "
                 "'error': raise ValueError."
             ),
+            default="suffix",
         ),
-    ] = "skip",
+    ] = "suffix",
 ) -> AnyDataFrame:
     """
     Maps and transforms the columns of a DataFrame based on the provided parameters. The order of the operations is as
@@ -347,21 +365,38 @@ def title_case_columns_by_prefix(
         str,
         Field(description="Column names prefixed with this value will be converted to title case."),
     ],
+    duplicate_strategy: Annotated[
+        RenameDuplicateStrategy,
+        AdvancedField(
+            description=(
+                "Strategy for handling a column whose new name is already taken. "
+                "'suffix': append _1, _2, etc. to the new name; "
+                "'skip': leave the column under its original name; "
+                "'overwrite': replace the existing column; "
+                "'error': raise ValueError."
+            ),
+            default="suffix",
+        ),
+    ] = "suffix",
 ) -> AnyDataFrame:
     """
     Convert the column names beginning with the provided prefix to title case.
-    A column whose title cased name is already taken is left under its original name.
 
     Args:
         df (AnyDataFrame): The input DataFrame.
         prefix (str): Column names prefixed with this value will be converted to title case.
+        duplicate_strategy (RenameDuplicateStrategy): How to handle a title cased name that is
+            already taken; see `_safe_rename_columns`. Defaults to suffixing, so no column is lost.
 
     Returns:
         AnyDataFrame: The updated DataFrame.
+
+    Raises:
+        ValueError: If `duplicate_strategy` is "error" and a title cased name is already taken.
     """
 
     mapping = {col: col.removeprefix(prefix).replace("_", " ").title() for col in df.columns if col.startswith(prefix)}
-    df = _safe_rename_columns(df, mapping)
+    df = _safe_rename_columns(df, mapping, duplicate_strategy)
 
     return cast(AnyDataFrame, df)
 
@@ -427,20 +462,37 @@ def strip_prefix_from_column_names(
         str,
         Field(description="The prefix to remove."),
     ],
+    duplicate_strategy: Annotated[
+        RenameDuplicateStrategy,
+        AdvancedField(
+            description=(
+                "Strategy for handling a column whose new name is already taken. "
+                "'suffix': append _1, _2, etc. to the new name; "
+                "'skip': leave the column under its original name; "
+                "'overwrite': replace the existing column; "
+                "'error': raise ValueError."
+            ),
+            default="suffix",
+        ),
+    ] = "suffix",
 ) -> AnyDataFrame:
     """
     Strip the provided prefix from column names that have it.
-    A column whose stripped name is already taken is left under its original name.
 
     Args:
         df (AnyDataFrame): The input DataFrame.
         prefix (str): The prefix to remove from column names in this dataframe.
+        duplicate_strategy (RenameDuplicateStrategy): How to handle a stripped name that is already
+            taken; see `_safe_rename_columns`. Defaults to suffixing, so no column is lost.
 
     Returns:
         AnyDataFrame: The updated DataFrame.
+
+    Raises:
+        ValueError: If `duplicate_strategy` is "error" and a stripped name is already taken.
     """
     mapping = {col: col.removeprefix(prefix) for col in df.columns}
-    df = _safe_rename_columns(df, mapping)
+    df = _safe_rename_columns(df, mapping, duplicate_strategy)
     return cast(AnyDataFrame, df)
 
 

--- a/ecoscope/platform/tasks/transformation/_mapping.py
+++ b/ecoscope/platform/tasks/transformation/_mapping.py
@@ -32,7 +32,7 @@ def map_values(
 ) -> AnyDataFrame:
     match missing_values:
         case "preserve":
-            df[column_name] = df[column_name].map(value_map).fillna(df[column_name])
+            df[column_name] = df[column_name].map(value_map).fillna(df7[column_name])
         case "remove":
             df[column_name] = df[column_name].map(value_map)
         case "replace":
@@ -106,7 +106,22 @@ def map_values_with_unit(
     return df
 
 
-RenameCollisionStrategy = Literal["overwrite", "skip", "error"]
+RenameDuplicateStrategy = Literal["overwrite", "skip", "error"]
+
+
+def _active_geometry_name(df: pd.DataFrame) -> str | None:
+    """
+    The name of the frame's active geometry column, or None if it has none.
+
+    Args:
+        df (pd.DataFrame): The DataFrame to inspect.
+
+    Returns:
+        str | None: The active geometry column name.
+    """
+    import geopandas as gpd  # type: ignore[import-untyped]
+
+    return df.active_geometry_name if isinstance(df, gpd.GeoDataFrame) else None
 
 
 def _find_rename_collisions(columns: Collection[str], mapping: dict[str, str]) -> dict[str, str]:
@@ -138,34 +153,40 @@ def _find_rename_collisions(columns: Collection[str], mapping: dict[str, str]) -
 def _safe_rename_columns(
     df: pd.DataFrame,
     rename_columns: dict[str, str],
-    collision_strategy: RenameCollisionStrategy = "overwrite",
+    duplicate_strategy: RenameDuplicateStrategy = "skip",
 ) -> pd.DataFrame:
     """
-    Rename columns, resolving new names that are already taken so that the result never contains
+    Rename columns, resolving new names that are already taken so that the renames never introduce
     duplicate column labels.
 
     `DataFrame.rename` will happily rename a column to a name that already exists, leaving the
     frame with duplicate labels. `df[name]` then returns a DataFrame rather than a Series, which
     tends to fail confusingly, far from the rename that caused it.
 
+    Duplicate labels among the columns that aren't being renamed are left alone; renaming a column
+    whose label is duplicated is an error, since it would carry the duplication over to the new
+    name. Use `drop_duplicate_columns` to resolve those first.
+
     Args:
         df (pd.DataFrame): The DataFrame to rename columns on.
         rename_columns (dict[str, str]): Mapping of existing column name to new column name.
-        collision_strategy (RenameCollisionStrategy): How to resolve a new name that is already
+        duplicate_strategy (RenameDuplicateStrategy): How to resolve a new name that is already
             taken, either by a column that isn't being renamed or by an earlier entry in
             `rename_columns`:
-            - "overwrite": drop the column holding the name so the renamed one takes it
             - "skip": skip the rename, leaving the column under its original name
+            - "overwrite": drop the column holding the name so the renamed one takes it
             - "error": raise ValueError
 
     Returns:
         pd.DataFrame: The DataFrame with columns renamed.
 
     Raises:
-        ValueError: If `collision_strategy` is "error" and a new name is already taken.
+        ValueError: If a column being renamed has a duplicated label, if `duplicate_strategy` is
+            "error" and a new name is already taken, or if overwriting would drop the active
+            geometry column.
     """
-    if collision_strategy not in get_args(RenameCollisionStrategy):
-        raise ValueError(f"Invalid selection for collision_strategy: {collision_strategy}")
+    if duplicate_strategy not in get_args(RenameDuplicateStrategy):
+        raise ValueError(f"Invalid selection for duplicate_strategy: {duplicate_strategy}")
 
     # Renames of absent columns are no-ops for pandas, so they can't collide, and identity
     # renames leave the column exactly where it is.
@@ -173,7 +194,14 @@ def _safe_rename_columns(
     if not mapping:
         return df
 
-    if collision_strategy == "error":
+    # Reject attempts to rename already duplicated column names
+    if duplicated := sorted({col for col in df.columns[df.columns.duplicated()] if col in mapping}):
+        raise ValueError(
+            f"Cannot rename columns {duplicated} because the DataFrame has more than one column "
+            "with each of those names. Resolve them first, eg. with `drop_duplicate_columns`."
+        )
+
+    if duplicate_strategy == "error":
         if collisions := _find_rename_collisions(df.columns, mapping):
             raise ValueError(
                 f"Renaming columns {mapping} would create duplicate columns: "
@@ -181,7 +209,7 @@ def _safe_rename_columns(
             )
         return df.rename(columns=mapping)
 
-    if collision_strategy == "skip":
+    if duplicate_strategy == "skip":
         # Skipping a rename leaves its original name occupied, which can collide with a rename
         # we had already accepted, so keep resolving until nothing collides.
         skipped: dict[str, str] = {}
@@ -206,6 +234,14 @@ def _safe_rename_columns(
         owner[new] = old
 
     if to_drop:
+        # Dropping the active geometry column leaves a GeoDataFrame with no geometry, which
+        # demotes it to a plain DataFrame and loses the CRS.
+        if (active_geometry := _active_geometry_name(df)) in to_drop:
+            raise ValueError(
+                f"Renaming columns {mapping} would overwrite the active geometry column "
+                f"'{active_geometry}'. Drop or rename it explicitly first, or use a "
+                "duplicate_strategy of 'skip' or 'error'."
+            )
         if "geometry" in to_drop:
             logger.warning("'geometry' is being overwritten by a rename, which may affect spatial operations.")
         logger.warning(f"Overwriting existing columns: {to_drop}")
@@ -241,18 +277,18 @@ def map_columns(
     raise_if_not_found: Annotated[
         bool, Field(description="Whether or not to raise if var is not in value_map.")
     ] = True,
-    collision_strategy: Annotated[
-        RenameCollisionStrategy,
+    duplicate_strategy: Annotated[
+        RenameDuplicateStrategy,
         AdvancedField(
-            default="overwrite",
+            default="skip",
             description=(
-                "How to handle a rename whose new name is already taken. "
-                "'overwrite': replace the existing column; "
+                "Strategy for handling a rename whose new name is already taken. "
                 "'skip': skip the rename, leaving the column under its original name; "
+                "'overwrite': replace the existing column; "
                 "'error': raise ValueError."
             ),
         ),
-    ] = "overwrite",
+    ] = "skip",
 ) -> AnyDataFrame:
     """
     Maps and transforms the columns of a DataFrame based on the provided parameters. The order of the operations is as
@@ -264,7 +300,7 @@ def map_columns(
         retain_columns (list[str]): List of columns to retain. The order of columns will be preserved.
         rename_columns (dict[str, str]): Dictionary of columns to rename.
         raise_if_not_found (bool): Whether or not to raise in the event a column is not found.
-        collision_strategy (RenameCollisionStrategy): How to handle renaming a column to a name that is
+        duplicate_strategy (RenameDuplicateStrategy): How to handle renaming a column to a name that is
             already taken; see `_safe_rename_columns`.
 
     Returns:
@@ -272,7 +308,9 @@ def map_columns(
 
     Raises:
         KeyError: If any of the columns specified are not found in the DataFrame.
-        ValueError: If `collision_strategy` is "error" and a new column name is already taken.
+        ValueError: If a column being renamed has a duplicated label, if `duplicate_strategy` is
+            "error" and a new column name is already taken, or if overwriting a name would drop
+            the active geometry column.
     """
 
     if drop_columns:
@@ -298,7 +336,7 @@ def map_columns(
             raise KeyError(
                 f"Columns {list(rename_columns.keys())} not all found in DataFrame. Existing columns: {df.columns}"
             )
-        df = _safe_rename_columns(df, rename_columns, collision_strategy)  # type: ignore[assignment]
+        df = _safe_rename_columns(df, rename_columns, duplicate_strategy)  # type: ignore[assignment]
 
     return cast(AnyDataFrame, df)
 
@@ -313,7 +351,7 @@ def title_case_columns_by_prefix(
 ) -> AnyDataFrame:
     """
     Convert the column names beginning with the provided prefix to title case.
-    A title cased name that is already taken overwrites the column holding it.
+    A column whose title cased name is already taken is left under its original name.
 
     Args:
         df (AnyDataFrame): The input DataFrame.
@@ -324,7 +362,7 @@ def title_case_columns_by_prefix(
     """
 
     mapping = {col: col.removeprefix(prefix).replace("_", " ").title() for col in df.columns if col.startswith(prefix)}
-    df = _safe_rename_columns(df, mapping, "overwrite")  # type: ignore[assignment]
+    df = _safe_rename_columns(df, mapping)  # type: ignore[assignment]
 
     return cast(AnyDataFrame, df)
 
@@ -393,7 +431,7 @@ def strip_prefix_from_column_names(
 ) -> AnyDataFrame:
     """
     Strip the provided prefix from column names that have it.
-    A stripped name that is already taken overwrites the column holding it.
+    A column whose stripped name is already taken is left under its original name.
 
     Args:
         df (AnyDataFrame): The input DataFrame.
@@ -403,7 +441,7 @@ def strip_prefix_from_column_names(
         AnyDataFrame: The updated DataFrame.
     """
     mapping = {col: col.removeprefix(prefix) for col in df.columns}
-    df = _safe_rename_columns(df, mapping, "overwrite")  # type: ignore[assignment]
+    df = _safe_rename_columns(df, mapping)  # type: ignore[assignment]
     return cast(AnyDataFrame, df)
 
 

--- a/ecoscope/platform/tasks/transformation/_mapping.py
+++ b/ecoscope/platform/tasks/transformation/_mapping.py
@@ -2,7 +2,6 @@ import logging
 from collections.abc import Collection
 from typing import Annotated, Literal, cast, get_args
 
-import pandas as pd
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 from wt_registry import register
@@ -109,12 +108,12 @@ def map_values_with_unit(
 RenameDuplicateStrategy = Literal["overwrite", "skip", "error"]
 
 
-def _active_geometry_name(df: pd.DataFrame) -> str | None:
+def _active_geometry_name(df: AnyDataFrame) -> str | None:
     """
     The name of the frame's active geometry column, or None if it has none.
 
     Args:
-        df (pd.DataFrame): The DataFrame to inspect.
+        df (AnyDataFrame): The DataFrame to inspect.
 
     Returns:
         str | None: The active geometry column name.
@@ -151,10 +150,10 @@ def _find_rename_collisions(columns: Collection[str], mapping: dict[str, str]) -
 
 
 def _safe_rename_columns(
-    df: pd.DataFrame,
+    df: AnyDataFrame,
     rename_columns: dict[str, str],
     duplicate_strategy: RenameDuplicateStrategy = "skip",
-) -> pd.DataFrame:
+) -> AnyDataFrame:
     """
     Rename columns, resolving new names that are already taken so that the renames never introduce
     duplicate column labels.
@@ -168,7 +167,7 @@ def _safe_rename_columns(
     name. Use `drop_duplicate_columns` to resolve those first.
 
     Args:
-        df (pd.DataFrame): The DataFrame to rename columns on.
+        df (AnyDataFrame): The DataFrame to rename columns on.
         rename_columns (dict[str, str]): Mapping of existing column name to new column name.
         duplicate_strategy (RenameDuplicateStrategy): How to resolve a new name that is already
             taken, either by a column that isn't being renamed or by an earlier entry in
@@ -178,7 +177,7 @@ def _safe_rename_columns(
             - "error": raise ValueError
 
     Returns:
-        pd.DataFrame: The DataFrame with columns renamed.
+        AnyDataFrame: The DataFrame with columns renamed.
 
     Raises:
         ValueError: If a column being renamed has a duplicated label, if `duplicate_strategy` is
@@ -207,7 +206,7 @@ def _safe_rename_columns(
                 f"Renaming columns {mapping} would create duplicate columns: "
                 f"{sorted(set(collisions.values()))}. Existing columns: {list(df.columns)}"
             )
-        return df.rename(columns=mapping)
+        return cast(AnyDataFrame, df.rename(columns=mapping))
 
     if duplicate_strategy == "skip":
         # Skipping a rename leaves its original name occupied, which can collide with a rename
@@ -218,7 +217,7 @@ def _safe_rename_columns(
             mapping = {old: new for old, new in mapping.items() if old not in collisions}
         if skipped:
             logger.warning(f"Not renaming columns whose new name is already taken: {skipped}")
-        return df.rename(columns=mapping)
+        return cast(AnyDataFrame, df.rename(columns=mapping))
 
     # "overwrite": track which column will hold each name, so that the last rename to a given
     # name wins and whatever held it - an untouched column, or a column renamed earlier - goes.
@@ -245,9 +244,9 @@ def _safe_rename_columns(
         if "geometry" in to_drop:
             logger.warning("'geometry' is being overwritten by a rename, which may affect spatial operations.")
         logger.warning(f"Overwriting existing columns: {to_drop}")
-        df = df.drop(columns=to_drop)
+        df = cast(AnyDataFrame, df.drop(columns=to_drop))
 
-    return df.rename(columns=resolved)
+    return cast(AnyDataFrame, df.rename(columns=resolved))
 
 
 class RenameColumn(BaseModel):
@@ -336,7 +335,7 @@ def map_columns(
             raise KeyError(
                 f"Columns {list(rename_columns.keys())} not all found in DataFrame. Existing columns: {df.columns}"
             )
-        df = _safe_rename_columns(df, rename_columns, duplicate_strategy)  # type: ignore[assignment]
+        df = _safe_rename_columns(df, rename_columns, duplicate_strategy)
 
     return cast(AnyDataFrame, df)
 
@@ -362,7 +361,7 @@ def title_case_columns_by_prefix(
     """
 
     mapping = {col: col.removeprefix(prefix).replace("_", " ").title() for col in df.columns if col.startswith(prefix)}
-    df = _safe_rename_columns(df, mapping)  # type: ignore[assignment]
+    df = _safe_rename_columns(df, mapping)
 
     return cast(AnyDataFrame, df)
 
@@ -441,7 +440,7 @@ def strip_prefix_from_column_names(
         AnyDataFrame: The updated DataFrame.
     """
     mapping = {col: col.removeprefix(prefix) for col in df.columns}
-    df = _safe_rename_columns(df, mapping)  # type: ignore[assignment]
+    df = _safe_rename_columns(df, mapping)
     return cast(AnyDataFrame, df)
 
 

--- a/tests/platform/tasks/test_column_mapping.py
+++ b/tests/platform/tasks/test_column_mapping.py
@@ -180,16 +180,16 @@ def test_reorder_columns():
     ]
 
 
-def test_rename_columns_skips_collision_by_default(sample_dataframe, caplog):
-    """By default a rename onto an existing column is skipped, rather than creating duplicate labels."""
+def test_rename_columns_suffixes_collision_by_default(sample_dataframe, caplog):
+    """By default a rename onto an existing column is suffixed, rather than creating duplicate labels."""
     with caplog.at_level(logging.WARNING):
         result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns={"A": "B"})
 
-    assert "Not renaming columns whose new name is already taken: {'A': 'B'}" in caplog.text
-    assert list(result_df.columns) == ["A", "B", "C"]
+    assert "Suffixing columns whose new name is already taken: {'A': 'B_1'}" in caplog.text
+    assert list(result_df.columns) == ["B_1", "B", "C"]
     assert result_df.columns.is_unique
     assert isinstance(result_df["B"], pd.Series)
-    assert result_df["A"].to_list() == [1, 2, 3]
+    assert result_df["B_1"].to_list() == [1, 2, 3]
     assert result_df["B"].to_list() == [4, 5, 6]
 
 
@@ -206,6 +206,33 @@ def test_rename_columns_duplicate_overwrite(sample_dataframe):
     assert result_df.columns.is_unique
     assert isinstance(result_df["B"], pd.Series)
     assert result_df["B"].to_list() == [1, 2, 3]
+
+
+def test_rename_columns_suffix_skips_taken_suffixes():
+    """The _1 suffix can itself be taken, so keep incrementing until the name is free."""
+    df = pd.DataFrame({"A": [1], "B": [2], "B_1": [3], "B_2": [4]})
+
+    result_df = map_columns(
+        df, drop_columns=[], retain_columns=[], rename_columns={"A": "B"}, duplicate_strategy="suffix"
+    )
+    assert list(result_df.columns) == ["B_3", "B", "B_1", "B_2"]
+    assert result_df.columns.is_unique
+    assert result_df["B_3"].to_list() == [1]
+
+
+def test_rename_columns_shared_new_name_suffix(sample_dataframe):
+    """Two columns renamed to the same name get distinct suffixes."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "Z", "B": "Z"},
+        duplicate_strategy="suffix",
+    )
+    assert list(result_df.columns) == ["Z", "Z_1", "C"]
+    assert result_df.columns.is_unique
+    assert result_df["Z"].to_list() == [1, 2, 3]
+    assert result_df["Z_1"].to_list() == [4, 5, 6]
 
 
 def test_rename_columns_duplicate_error(sample_dataframe):
@@ -237,7 +264,7 @@ def test_rename_columns_duplicate_skip_cascades(sample_dataframe):
     assert result_df["C"].to_list() == [7, 8, 9]
 
 
-@pytest.mark.parametrize("duplicate_strategy", ["overwrite", "skip", "error"])
+@pytest.mark.parametrize("duplicate_strategy", ["skip", "suffix", "overwrite", "error"])
 def test_rename_columns_swap_is_not_a_duplicate(sample_dataframe, duplicate_strategy):
     """Swapping two column names does not create duplicates, under any strategy."""
     result_df = map_columns(
@@ -273,6 +300,7 @@ def test_rename_columns_shared_new_name_skip(sample_dataframe):
         drop_columns=[],
         retain_columns=[],
         rename_columns={"A": "Z", "B": "Z"},
+        duplicate_strategy="skip",
     )
     assert list(result_df.columns) == ["Z", "B", "C"]
     assert result_df["Z"].to_list() == [1, 2, 3]
@@ -303,12 +331,12 @@ def test_rename_columns_missing_column_is_not_a_duplicate(sample_dataframe):
     assert result_df["B"].to_list() == [4, 5, 6]
 
 
-def test_rename_columns_with_list_skips_collision(sample_dataframe):
+def test_rename_columns_with_list_suffixes_collision(sample_dataframe):
     """Duplicates are resolved the same way when renames are given as a list."""
     rename_list = [RenameColumn(original_name="A", new_name="B")]
     result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns=rename_list)
-    assert list(result_df.columns) == ["A", "B", "C"]
-    assert result_df["A"].to_list() == [1, 2, 3]
+    assert list(result_df.columns) == ["B_1", "B", "C"]
+    assert result_df["B_1"].to_list() == [1, 2, 3]
     assert result_df["B"].to_list() == [4, 5, 6]
 
 
@@ -366,8 +394,8 @@ def test_rename_columns_overwriting_active_geometry_raises(sample_geodataframe, 
         )
 
 
-def test_rename_columns_skips_active_geometry_by_default(sample_geodataframe):
-    """The default strategy leaves the active geometry, and so the frame's spatial-ness, intact."""
+def test_rename_columns_default_preserves_active_geometry(sample_geodataframe):
+    """The default strategy drops nothing, so the frame keeps its geometry and CRS."""
     result_gdf = map_columns(
         sample_geodataframe, drop_columns=[], retain_columns=[], rename_columns={"the_geom": "geometry"}
     )
@@ -375,7 +403,7 @@ def test_rename_columns_skips_active_geometry_by_default(sample_geodataframe):
     assert isinstance(result_gdf, gpd.GeoDataFrame)
     assert result_gdf.active_geometry_name == "geometry"
     assert result_gdf.crs == "EPSG:4326"
-    assert list(result_gdf.columns) == ["A", "the_geom", "geometry"]
+    assert list(result_gdf.columns) == ["A", "geometry_1", "geometry"]
 
 
 def test_rename_columns_overwrite_preserves_geodataframe(sample_geodataframe):
@@ -407,7 +435,7 @@ def test_rename_columns_geometry_can_be_replaced_by_dropping_it_first(sample_geo
 
 
 def test_title_case_columns_by_prefix_collision():
-    """A column whose title cased name is already taken keeps its original name."""
+    """A title cased name that is already taken is suffixed, so neither column is lost."""
     df = pd.DataFrame(
         data={
             "Another Value": [1, 2, 3],
@@ -416,9 +444,10 @@ def test_title_case_columns_by_prefix_collision():
     )
 
     df = title_case_columns_by_prefix(df, prefix="extra__")
-    assert df.columns.to_list() == ["Another Value", "extra__another_value"]
+    assert df.columns.to_list() == ["Another Value", "Another Value_1"]
     assert df.columns.is_unique
     assert df["Another Value"].to_list() == [1, 2, 3]
+    assert df["Another Value_1"].to_list() == [4, 5, 6]
 
 
 def test_strip_prefix_from_column_names():
@@ -429,10 +458,43 @@ def test_strip_prefix_from_column_names():
 
 
 def test_strip_prefix_from_column_names_collision():
-    """A column whose stripped name is already taken keeps its prefix."""
+    """A stripped name that is already taken is suffixed, so neither column is lost."""
     df = pd.DataFrame(data={"extra__a": [1, 2, 3], "a": [4, 5, 6]})
 
     df = strip_prefix_from_column_names(df, prefix="extra__")
-    assert df.columns.to_list() == ["extra__a", "a"]
+    assert df.columns.to_list() == ["a_1", "a"]
     assert df.columns.is_unique
+    assert df["a_1"].to_list() == [1, 2, 3]
     assert df["a"].to_list() == [4, 5, 6]
+
+
+@pytest.mark.parametrize(
+    ("duplicate_strategy", "expected"),
+    [
+        ("suffix", ["a_1", "a"]),
+        ("skip", ["extra__a", "a"]),
+        ("overwrite", ["a"]),
+    ],
+)
+def test_strip_prefix_from_column_names_duplicate_strategy(duplicate_strategy, expected):
+    """The strategy is a task parameter, so a workflow can pick a different one."""
+    df = pd.DataFrame(data={"extra__a": [1, 2, 3], "a": [4, 5, 6]})
+
+    df = strip_prefix_from_column_names(df, prefix="extra__", duplicate_strategy=duplicate_strategy)
+    assert df.columns.to_list() == expected
+    assert df.columns.is_unique
+
+
+def test_strip_prefix_from_column_names_duplicate_strategy_error():
+    df = pd.DataFrame(data={"extra__a": [1, 2, 3], "a": [4, 5, 6]})
+
+    with pytest.raises(ValueError, match=r"would create duplicate columns: \['a'\]"):
+        strip_prefix_from_column_names(df, prefix="extra__", duplicate_strategy="error")
+
+
+def test_title_case_columns_by_prefix_duplicate_strategy():
+    """The strategy is a task parameter here too."""
+    df = pd.DataFrame(data={"Another Value": [1, 2, 3], "extra__another_value": [4, 5, 6]})
+
+    df = title_case_columns_by_prefix(df, prefix="extra__", duplicate_strategy="skip")
+    assert df.columns.to_list() == ["Another Value", "extra__another_value"]

--- a/tests/platform/tasks/test_column_mapping.py
+++ b/tests/platform/tasks/test_column_mapping.py
@@ -180,16 +180,35 @@ def test_reorder_columns():
     ]
 
 
-def test_rename_columns_overwrites_existing_by_default(sample_dataframe):
-    """Renaming onto an existing column replaces it, rather than creating duplicate labels."""
-    result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns={"A": "B"})
+def test_rename_columns_skips_collision_by_default(sample_dataframe, caplog):
+    """By default a rename onto an existing column is skipped, rather than creating duplicate labels."""
+    with caplog.at_level(logging.WARNING):
+        result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns={"A": "B"})
+
+    assert "Not renaming columns whose new name is already taken: {'A': 'B'}" in caplog.text
+    assert list(result_df.columns) == ["A", "B", "C"]
+    assert result_df.columns.is_unique
+    assert isinstance(result_df["B"], pd.Series)
+    assert result_df["A"].to_list() == [1, 2, 3]
+    assert result_df["B"].to_list() == [4, 5, 6]
+
+
+def test_rename_columns_duplicate_overwrite(sample_dataframe):
+    """Test replacing the existing column when its name is taken by a rename."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "B"},
+        duplicate_strategy="overwrite",
+    )
     assert list(result_df.columns) == ["B", "C"]
     assert result_df.columns.is_unique
     assert isinstance(result_df["B"], pd.Series)
     assert result_df["B"].to_list() == [1, 2, 3]
 
 
-def test_rename_columns_collision_error(sample_dataframe):
+def test_rename_columns_duplicate_error(sample_dataframe):
     """Test raising if a new column name is already taken."""
     with pytest.raises(ValueError, match=r"would create duplicate columns: \['B'\]"):
         map_columns(
@@ -197,25 +216,11 @@ def test_rename_columns_collision_error(sample_dataframe):
             drop_columns=[],
             retain_columns=[],
             rename_columns={"A": "B"},
-            collision_strategy="error",
+            duplicate_strategy="error",
         )
 
 
-def test_rename_columns_collision_skip(sample_dataframe):
-    """Test skipping the rename if its new name is already taken."""
-    result_df = map_columns(
-        sample_dataframe,
-        drop_columns=[],
-        retain_columns=[],
-        rename_columns={"A": "B"},
-        collision_strategy="skip",
-    )
-    assert list(result_df.columns) == ["A", "B", "C"]
-    assert result_df["A"].to_list() == [1, 2, 3]
-    assert result_df["B"].to_list() == [4, 5, 6]
-
-
-def test_rename_columns_collision_skip_cascades(sample_dataframe):
+def test_rename_columns_duplicate_skip_cascades(sample_dataframe):
     """Skipping a rename keeps its original name taken, which can knock out a rename onto that name."""
     result_df = map_columns(
         sample_dataframe,
@@ -224,7 +229,7 @@ def test_rename_columns_collision_skip_cascades(sample_dataframe):
         # "C" -> "B" collides with "A" -> "B", so "C" stays put, which in turn collides with
         # "B" -> "C", so "B" stays put, which finally collides with "A" -> "B".
         rename_columns={"A": "B", "B": "C", "C": "B"},
-        collision_strategy="skip",
+        duplicate_strategy="skip",
     )
     assert list(result_df.columns) == ["A", "B", "C"]
     assert result_df["A"].to_list() == [1, 2, 3]
@@ -232,15 +237,15 @@ def test_rename_columns_collision_skip_cascades(sample_dataframe):
     assert result_df["C"].to_list() == [7, 8, 9]
 
 
-@pytest.mark.parametrize("collision_strategy", ["overwrite", "skip", "error"])
-def test_rename_columns_swap_is_not_a_collision(sample_dataframe, collision_strategy):
-    """Swapping two column names is not a collision, under any strategy."""
+@pytest.mark.parametrize("duplicate_strategy", ["overwrite", "skip", "error"])
+def test_rename_columns_swap_is_not_a_duplicate(sample_dataframe, duplicate_strategy):
+    """Swapping two column names does not create duplicates, under any strategy."""
     result_df = map_columns(
         sample_dataframe,
         drop_columns=[],
         retain_columns=[],
         rename_columns={"A": "B", "B": "A"},
-        collision_strategy=collision_strategy,
+        duplicate_strategy=duplicate_strategy,
     )
     assert list(result_df.columns) == ["B", "A", "C"]
     assert result_df["B"].to_list() == [1, 2, 3]
@@ -254,6 +259,7 @@ def test_rename_columns_shared_new_name_overwrite(sample_dataframe):
         drop_columns=[],
         retain_columns=[],
         rename_columns={"A": "Z", "B": "Z"},
+        duplicate_strategy="overwrite",
     )
     assert list(result_df.columns) == ["Z", "C"]
     assert result_df.columns.is_unique
@@ -267,7 +273,6 @@ def test_rename_columns_shared_new_name_skip(sample_dataframe):
         drop_columns=[],
         retain_columns=[],
         rename_columns={"A": "Z", "B": "Z"},
-        collision_strategy="skip",
     )
     assert list(result_df.columns) == ["Z", "B", "C"]
     assert result_df["Z"].to_list() == [1, 2, 3]
@@ -281,11 +286,11 @@ def test_rename_columns_shared_new_name_error(sample_dataframe):
             drop_columns=[],
             retain_columns=[],
             rename_columns={"A": "Z", "B": "Z"},
-            collision_strategy="error",
+            duplicate_strategy="error",
         )
 
 
-def test_rename_columns_missing_column_is_not_a_collision(sample_dataframe):
+def test_rename_columns_missing_column_is_not_a_duplicate(sample_dataframe):
     """A rename of a column that isn't present leaves the existing target untouched."""
     result_df = map_columns(
         sample_dataframe,
@@ -298,43 +303,111 @@ def test_rename_columns_missing_column_is_not_a_collision(sample_dataframe):
     assert result_df["B"].to_list() == [4, 5, 6]
 
 
-def test_rename_columns_with_list_overwrites_existing(sample_dataframe):
-    """Collisions are resolved the same way when renames are given as a list."""
+def test_rename_columns_with_list_skips_collision(sample_dataframe):
+    """Duplicates are resolved the same way when renames are given as a list."""
     rename_list = [RenameColumn(original_name="A", new_name="B")]
     result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns=rename_list)
-    assert list(result_df.columns) == ["B", "C"]
-    assert result_df["B"].to_list() == [1, 2, 3]
+    assert list(result_df.columns) == ["A", "B", "C"]
+    assert result_df["A"].to_list() == [1, 2, 3]
+    assert result_df["B"].to_list() == [4, 5, 6]
 
 
-def test_rename_columns_invalid_collision_strategy(sample_dataframe):
-    with pytest.raises(ValueError, match="Invalid selection for collision_strategy"):
+def test_rename_columns_invalid_duplicate_strategy(sample_dataframe):
+    with pytest.raises(ValueError, match="Invalid selection for duplicate_strategy"):
         map_columns(
             sample_dataframe,
             drop_columns=[],
             retain_columns=[],
             rename_columns={"A": "B"},
-            collision_strategy="not_a_strategy",  # type: ignore[arg-type]
+            duplicate_strategy="not_a_strategy",  # type: ignore[arg-type]
         )
 
 
-def test_rename_columns_overwriting_geometry_warns(caplog):
-    """Overwriting a geometry column is allowed, but noisy."""
-    gdf = gpd.GeoDataFrame(
+def test_rename_columns_renaming_a_duplicated_column_raises():
+    """Renaming a duplicated label would rename every column holding it, so refuse to."""
+    df = pd.DataFrame([[1, 2, 3]], columns=["A", "A", "B"])
+
+    with pytest.raises(ValueError, match=r"Cannot rename columns \['A'\]"):
+        map_columns(df, drop_columns=[], retain_columns=[], rename_columns={"A": "Z"})
+
+
+def test_rename_columns_leaves_untouched_duplicated_columns_alone():
+    """Duplicate labels among the columns we aren't renaming are none of our business."""
+    df = pd.DataFrame([[1, 2, 3]], columns=["A", "A", "B"])
+
+    result_df = map_columns(df, drop_columns=[], retain_columns=[], rename_columns={"B": "Z"})
+    assert list(result_df.columns) == ["A", "A", "Z"]
+
+
+@pytest.fixture
+def sample_geodataframe():
+    """A GeoDataFrame with a second, plain object column of geometries."""
+    return gpd.GeoDataFrame(
         data={"A": [1, 2], "the_geom": [Point(0, 0), Point(1, 1)]},
         geometry=[Point(2, 2), Point(3, 3)],
+        crs="EPSG:4326",
     )
 
-    with caplog.at_level(logging.WARNING):
-        result_gdf = map_columns(gdf, drop_columns=[], retain_columns=[], rename_columns={"the_geom": "geometry"})
 
-    assert "'geometry' is being overwritten by a rename" in caplog.text
+@pytest.mark.parametrize("active_geometry", ["geometry", "geom"])
+def test_rename_columns_overwriting_active_geometry_raises(sample_geodataframe, active_geometry):
+    """Overwriting the active geometry column would demote the frame to a plain DataFrame."""
+    gdf = sample_geodataframe
+    if active_geometry != gdf.active_geometry_name:
+        gdf = gdf.rename_geometry(active_geometry)
+
+    with pytest.raises(ValueError, match=f"would overwrite the active geometry column '{active_geometry}'"):
+        map_columns(
+            gdf,
+            drop_columns=[],
+            retain_columns=[],
+            rename_columns={"the_geom": active_geometry},
+            duplicate_strategy="overwrite",
+        )
+
+
+def test_rename_columns_skips_active_geometry_by_default(sample_geodataframe):
+    """The default strategy leaves the active geometry, and so the frame's spatial-ness, intact."""
+    result_gdf = map_columns(
+        sample_geodataframe, drop_columns=[], retain_columns=[], rename_columns={"the_geom": "geometry"}
+    )
+
+    assert isinstance(result_gdf, gpd.GeoDataFrame)
+    assert result_gdf.active_geometry_name == "geometry"
+    assert result_gdf.crs == "EPSG:4326"
+    assert list(result_gdf.columns) == ["A", "the_geom", "geometry"]
+
+
+def test_rename_columns_overwrite_preserves_geodataframe(sample_geodataframe):
+    """Overwriting a column that isn't the geometry keeps the frame a GeoDataFrame, CRS and all."""
+    result_gdf = map_columns(
+        sample_geodataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "the_geom"},
+        duplicate_strategy="overwrite",
+    )
+
+    assert isinstance(result_gdf, gpd.GeoDataFrame)
+    assert result_gdf.active_geometry_name == "geometry"
+    assert result_gdf.crs == "EPSG:4326"
+    assert list(result_gdf.columns) == ["the_geom", "geometry"]
+    assert result_gdf["the_geom"].to_list() == [1, 2]
+
+
+def test_rename_columns_geometry_can_be_replaced_by_dropping_it_first(sample_geodataframe):
+    """Replacing the geometry is still possible, but it has to be asked for explicitly."""
+    result_gdf = map_columns(
+        sample_geodataframe, drop_columns=["geometry"], retain_columns=[], rename_columns={"the_geom": "geometry"}
+    )
+
     assert list(result_gdf.columns) == ["A", "geometry"]
     assert result_gdf.columns.is_unique
     assert result_gdf["geometry"].to_list() == [Point(0, 0), Point(1, 1)]
 
 
 def test_title_case_columns_by_prefix_collision():
-    """A title cased column name that is already taken overwrites it, rather than duplicating it."""
+    """A column whose title cased name is already taken keeps its original name."""
     df = pd.DataFrame(
         data={
             "Another Value": [1, 2, 3],
@@ -343,9 +416,9 @@ def test_title_case_columns_by_prefix_collision():
     )
 
     df = title_case_columns_by_prefix(df, prefix="extra__")
-    assert df.columns.to_list() == ["Another Value"]
+    assert df.columns.to_list() == ["Another Value", "extra__another_value"]
     assert df.columns.is_unique
-    assert df["Another Value"].to_list() == [4, 5, 6]
+    assert df["Another Value"].to_list() == [1, 2, 3]
 
 
 def test_strip_prefix_from_column_names():
@@ -356,10 +429,10 @@ def test_strip_prefix_from_column_names():
 
 
 def test_strip_prefix_from_column_names_collision():
-    """A stripped column name that is already taken overwrites it, rather than duplicating it."""
+    """A column whose stripped name is already taken keeps its prefix."""
     df = pd.DataFrame(data={"extra__a": [1, 2, 3], "a": [4, 5, 6]})
 
     df = strip_prefix_from_column_names(df, prefix="extra__")
-    assert df.columns.to_list() == ["a"]
+    assert df.columns.to_list() == ["extra__a", "a"]
     assert df.columns.is_unique
-    assert df["a"].to_list() == [1, 2, 3]
+    assert df["a"].to_list() == [4, 5, 6]

--- a/tests/platform/tasks/test_column_mapping.py
+++ b/tests/platform/tasks/test_column_mapping.py
@@ -1,9 +1,14 @@
+import logging
+
+import geopandas as gpd
 import pandas as pd
 import pytest
+from shapely.geometry import Point
 
 from ecoscope.platform.tasks.transformation import (
     map_columns,
     reorder_columns,
+    strip_prefix_from_column_names,
     title_case_columns_by_prefix,
 )
 from ecoscope.platform.tasks.transformation._mapping import RenameColumn
@@ -173,3 +178,188 @@ def test_reorder_columns():
         "another_value",
         "a_value",
     ]
+
+
+def test_rename_columns_overwrites_existing_by_default(sample_dataframe):
+    """Renaming onto an existing column replaces it, rather than creating duplicate labels."""
+    result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns={"A": "B"})
+    assert list(result_df.columns) == ["B", "C"]
+    assert result_df.columns.is_unique
+    assert isinstance(result_df["B"], pd.Series)
+    assert result_df["B"].to_list() == [1, 2, 3]
+
+
+def test_rename_columns_collision_error(sample_dataframe):
+    """Test raising if a new column name is already taken."""
+    with pytest.raises(ValueError, match=r"would create duplicate columns: \['B'\]"):
+        map_columns(
+            sample_dataframe,
+            drop_columns=[],
+            retain_columns=[],
+            rename_columns={"A": "B"},
+            collision_strategy="error",
+        )
+
+
+def test_rename_columns_collision_skip(sample_dataframe):
+    """Test skipping the rename if its new name is already taken."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "B"},
+        collision_strategy="skip",
+    )
+    assert list(result_df.columns) == ["A", "B", "C"]
+    assert result_df["A"].to_list() == [1, 2, 3]
+    assert result_df["B"].to_list() == [4, 5, 6]
+
+
+def test_rename_columns_collision_skip_cascades(sample_dataframe):
+    """Skipping a rename keeps its original name taken, which can knock out a rename onto that name."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        # "C" -> "B" collides with "A" -> "B", so "C" stays put, which in turn collides with
+        # "B" -> "C", so "B" stays put, which finally collides with "A" -> "B".
+        rename_columns={"A": "B", "B": "C", "C": "B"},
+        collision_strategy="skip",
+    )
+    assert list(result_df.columns) == ["A", "B", "C"]
+    assert result_df["A"].to_list() == [1, 2, 3]
+    assert result_df["B"].to_list() == [4, 5, 6]
+    assert result_df["C"].to_list() == [7, 8, 9]
+
+
+@pytest.mark.parametrize("collision_strategy", ["overwrite", "skip", "error"])
+def test_rename_columns_swap_is_not_a_collision(sample_dataframe, collision_strategy):
+    """Swapping two column names is not a collision, under any strategy."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "B", "B": "A"},
+        collision_strategy=collision_strategy,
+    )
+    assert list(result_df.columns) == ["B", "A", "C"]
+    assert result_df["B"].to_list() == [1, 2, 3]
+    assert result_df["A"].to_list() == [4, 5, 6]
+
+
+def test_rename_columns_shared_new_name_overwrite(sample_dataframe):
+    """When two columns are renamed to the same name, the last one wins."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "Z", "B": "Z"},
+    )
+    assert list(result_df.columns) == ["Z", "C"]
+    assert result_df.columns.is_unique
+    assert result_df["Z"].to_list() == [4, 5, 6]
+
+
+def test_rename_columns_shared_new_name_skip(sample_dataframe):
+    """When two columns are renamed to the same name, the second rename is skipped."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"A": "Z", "B": "Z"},
+        collision_strategy="skip",
+    )
+    assert list(result_df.columns) == ["Z", "B", "C"]
+    assert result_df["Z"].to_list() == [1, 2, 3]
+    assert result_df["B"].to_list() == [4, 5, 6]
+
+
+def test_rename_columns_shared_new_name_error(sample_dataframe):
+    with pytest.raises(ValueError, match=r"would create duplicate columns: \['Z'\]"):
+        map_columns(
+            sample_dataframe,
+            drop_columns=[],
+            retain_columns=[],
+            rename_columns={"A": "Z", "B": "Z"},
+            collision_strategy="error",
+        )
+
+
+def test_rename_columns_missing_column_is_not_a_collision(sample_dataframe):
+    """A rename of a column that isn't present leaves the existing target untouched."""
+    result_df = map_columns(
+        sample_dataframe,
+        drop_columns=[],
+        retain_columns=[],
+        rename_columns={"NOT_EXIST": "B"},
+        raise_if_not_found=False,
+    )
+    assert list(result_df.columns) == ["A", "B", "C"]
+    assert result_df["B"].to_list() == [4, 5, 6]
+
+
+def test_rename_columns_with_list_overwrites_existing(sample_dataframe):
+    """Collisions are resolved the same way when renames are given as a list."""
+    rename_list = [RenameColumn(original_name="A", new_name="B")]
+    result_df = map_columns(sample_dataframe, drop_columns=[], retain_columns=[], rename_columns=rename_list)
+    assert list(result_df.columns) == ["B", "C"]
+    assert result_df["B"].to_list() == [1, 2, 3]
+
+
+def test_rename_columns_invalid_collision_strategy(sample_dataframe):
+    with pytest.raises(ValueError, match="Invalid selection for collision_strategy"):
+        map_columns(
+            sample_dataframe,
+            drop_columns=[],
+            retain_columns=[],
+            rename_columns={"A": "B"},
+            collision_strategy="not_a_strategy",  # type: ignore[arg-type]
+        )
+
+
+def test_rename_columns_overwriting_geometry_warns(caplog):
+    """Overwriting a geometry column is allowed, but noisy."""
+    gdf = gpd.GeoDataFrame(
+        data={"A": [1, 2], "the_geom": [Point(0, 0), Point(1, 1)]},
+        geometry=[Point(2, 2), Point(3, 3)],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result_gdf = map_columns(gdf, drop_columns=[], retain_columns=[], rename_columns={"the_geom": "geometry"})
+
+    assert "'geometry' is being overwritten by a rename" in caplog.text
+    assert list(result_gdf.columns) == ["A", "geometry"]
+    assert result_gdf.columns.is_unique
+    assert result_gdf["geometry"].to_list() == [Point(0, 0), Point(1, 1)]
+
+
+def test_title_case_columns_by_prefix_collision():
+    """A title cased column name that is already taken overwrites it, rather than duplicating it."""
+    df = pd.DataFrame(
+        data={
+            "Another Value": [1, 2, 3],
+            "extra__another_value": [4, 5, 6],
+        }
+    )
+
+    df = title_case_columns_by_prefix(df, prefix="extra__")
+    assert df.columns.to_list() == ["Another Value"]
+    assert df.columns.is_unique
+    assert df["Another Value"].to_list() == [4, 5, 6]
+
+
+def test_strip_prefix_from_column_names():
+    df = pd.DataFrame(data={"extra__a": [1, 2, 3], "b": [4, 5, 6]})
+
+    df = strip_prefix_from_column_names(df, prefix="extra__")
+    assert df.columns.to_list() == ["a", "b"]
+
+
+def test_strip_prefix_from_column_names_collision():
+    """A stripped column name that is already taken overwrites it, rather than duplicating it."""
+    df = pd.DataFrame(data={"extra__a": [1, 2, 3], "a": [4, 5, 6]})
+
+    df = strip_prefix_from_column_names(df, prefix="extra__")
+    assert df.columns.to_list() == ["a"]
+    assert df.columns.is_unique
+    assert df["a"].to_list() == [1, 2, 3]


### PR DESCRIPTION
## :earth_americas: Summary
Closes #835 

## :package: Proposed Changes
- Adds a `_safe_rename_columns` utility shared by tasks in `_mapping` that rely on `df.rename`
- Adds a `duplicate_strategy` arg to `map_columns` allowing users to chose either "suffix", "skip", "overwrite", or "error".
  - Uses "prefix" as the default as that seems safest in the average case, though much of our consuming workflows will want "overwrite".
- Additionally to `map_columns`, `duplicate_strategy` is also wired up as args on `title_case_columns_by_prefix` and `strip_prefix_from_column_names`

## 📋 Checklist
- [x] Corresponding ecoscope.platform tasks updated if necessary